### PR TITLE
Remove asyncio from server requirements

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -2,4 +2,3 @@ flask
 websockets
 google-generativeai
 python-dotenv
-asyncio


### PR DESCRIPTION
## Summary
- clean up `server/requirements.txt` by dropping `asyncio`

## Testing
- `python -m py_compile server/*.py`
- `pip install -r server/requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68407bd50da88328a9725bdefd6d25d5