### PR TITLE
Investigate dermatopathology findings loading issue

### DIFF
--- a/apps/dermpath ddxs.html
+++ b/apps/dermpath ddxs.html
@@ -1638,11 +1638,25 @@
                         name: processedFindingsMap.get(key).displayFindingName
                     }));
 
-                    fuseInstance = new Fuse(searchData, {
-                        keys: ['name'],
-                        threshold: 0.3,
-                        includeScore: true
-                    });
+                    if (typeof Fuse === 'function') {
+                        fuseInstance = new Fuse(searchData, {
+                            keys: ['name'],
+                            threshold: 0.3,
+                            includeScore: true
+                        });
+                    } else {
+                        console.warn('Fuse.js not available; falling back to basic substring search');
+                        // Minimal fallback so the app still works without Fuse
+                        fuseInstance = {
+                            search(query) {
+                                const lower = String(query || '').toLowerCase();
+                                return searchData
+                                    .filter(item => item.name.toLowerCase().includes(lower))
+                                    .slice(0, 20)
+                                    .map(item => ({ item, score: 0 }));
+                            }
+                        };
+                    }
 
                     populateFindingSelectors();
                     initializeEventListeners();


### PR DESCRIPTION
Add a fallback for Fuse.js initialization to ensure the dermatopathology findings dropdown populates even if the Fuse.js CDN fails to load.

The original code would throw an error if `Fuse` was undefined (e.g., due to CDN issues), preventing the subsequent population of the findings dropdown. This change ensures that the dropdown is still populated, using a basic substring search if Fuse.js is unavailable, thus improving resilience.

---
<a href="https://cursor.com/background-agent?bcId=bc-bb0c91dd-146b-4b25-97e4-46d5b7b6d4e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bb0c91dd-146b-4b25-97e4-46d5b7b6d4e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

