### PR TITLE
Fix: Use correct variable name for differential data

### DIFF
--- a/apps/dermpath ddxs.html
+++ b/apps/dermpath ddxs.html
@@ -1594,11 +1594,11 @@
         return new Promise((resolve) => {
             setTimeout(() => {
                 try {
-                    if (typeof differentialsData === 'undefined') {
+                    if (typeof window.dermDifferentialData === 'undefined') {
                         throw new Error('Differential diagnosis data not found');
                     }
 
-                    const findingsData = differentialsData;
+                    const findingsData = window.dermDifferentialData;
                     console.log('Processing', findingsData.length, 'findings...');
                     processedFindingsMap.clear();
 
@@ -2637,9 +2637,9 @@
      document.addEventListener('DOMContentLoaded', () => {
          console.log('Initializing Dermatopathology Navigator Pro...');
          console.log('DOM loaded, checking script availability...');
-        console.log('dermDifferentialData available:', typeof differentialsData !== 'undefined');
-        if (typeof differentialsData !== 'undefined') {
-            console.log('Data length:', differentialsData.length);
+        console.log('dermDifferentialData available:', typeof window.dermDifferentialData !== 'undefined');
+        if (typeof window.dermDifferentialData !== 'undefined') {
+            console.log('Data length:', window.dermDifferentialData.length);
         }
          initializeApplication();
      });


### PR DESCRIPTION
The dropdown menu in the dermatopathology navigator was not populating because the JavaScript code was attempting to access `differentialsData`, which was undefined. The data from `dermpathDifferentialsData.js` is assigned to the global variable `window.dermDifferentialData`.

This commit corrects the variable name in `apps/dermpath ddxs.html` to `window.dermDifferentialData`, allowing the application to correctly load the data and populate the dropdown menu.