### PR TITLE
feat: Refactor flashcards to be like Anki

### DIFF
--- a/apps/dermpath ddxs.html
+++ b/apps/dermpath ddxs.html
@@ -14,6 +14,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
 
     <!-- Custom CSS -->
+    <link rel="stylesheet" href="dermatology-study-system/css/flashcards.css">
     <style>
         /* Design System using CSS Variables */
         :root {
@@ -82,18 +83,6 @@
         .btn-primary:hover { background-color: var(--color-primary-hover); }
         .btn-secondary { background-color: transparent; border: 1px solid var(--color-border); color: var(--color-text); }
         .btn-secondary:hover { background-color: var(--color-bg); }
-        
-        /* Flashcard Styles */
-        .flashcard-scene { perspective: 1000px; }
-        .flashcard {
-            transform-style: preserve-3d;
-            transition: transform 0.6s;
-        }
-        .flashcard.is-flipped { transform: rotateY(180deg); }
-        .flashcard-face {
-            backface-visibility: hidden; -webkit-backface-visibility: hidden;
-        }
-        .flashcard-back { transform: rotateY(180deg); }
         
         /* Toast Notifications */
         #toast-container { position: fixed; bottom: 1.5rem; right: 1.5rem; z-index: 100; }
@@ -261,6 +250,11 @@
                 views: {}, // { "findingName": { count: 1, lastViewed: timestamp } }
                 tabUsage: {},
                 actions: { favorites: 0, notes: 0, exports: 0 }
+            },
+            flashcard: {
+                deck: [],
+                currentIndex: 0,
+                isShuffled: false
             }
         };
 
@@ -639,36 +633,108 @@
         }
 
         function renderFlashcardsView(diagnoses) {
-             if (!diagnoses || diagnoses.length === 0) {
-                 dom.resultsContent.innerHTML = `<div class="text-center p-8 text-gray-500">No diagnoses to create flashcards for.</div>`;
+            if (!diagnoses || diagnoses.length === 0) {
+                dom.resultsContent.innerHTML = `<div class="text-center p-8 text-gray-500">No diagnoses to create flashcards for.</div>`;
                 return;
             }
-            
-            const flashcardHTML = diagnoses.map((dx, index) => `
-                <div class="flashcard-scene w-full h-64 mb-6">
-                    <div class="flashcard relative w-full h-full" id="flashcard-${index}">
-                        <!-- Front Face -->
-                        <div class="flashcard-face absolute w-full h-full p-6 flex flex-col items-center justify-center bg-white dark:bg-gray-800 rounded-lg shadow-md border dark:border-gray-700">
-                            <h3 class="text-xl font-bold text-center">${dx.name}</h3>
-                            <p class="text-sm text-gray-500 mt-2">Click to flip</p>
-                        </div>
-                        <!-- Back Face -->
-                        <div class="flashcard-back absolute w-full h-full p-6 flex flex-col justify-center bg-blue-100 dark:bg-blue-900/50 rounded-lg shadow-md border border-blue-300 dark:border-blue-700">
-                            <p class="text-sm text-gray-800 dark:text-gray-200"><strong class="font-semibold">Key Features:</strong> ${dx.keyFeatures}</p>
-                            <p class="text-xs font-mono text-gray-600 dark:text-gray-400 mt-3">Source: ${formatSources(dx.sources)}</p>
+
+            // Initialize or update flashcard deck
+            if (state.flashcard.deck.length === 0 || state.flashcard.deck[0].finding !== state.selectedFinding) {
+                state.flashcard.deck = diagnoses.map(dx => ({...dx, finding: state.selectedFinding}));
+                state.flashcard.currentIndex = 0;
+                state.flashcard.isShuffled = false;
+            }
+
+            const currentCard = state.flashcard.deck[state.flashcard.currentIndex];
+
+            const html = `
+                <div class="flashcard-container">
+                    <div class="flashcard-nav">
+                        <button id="flashcard-prev" class="btn-secondary px-3 py-1 rounded-md" ${state.flashcard.currentIndex === 0 ? 'disabled' : ''}>&larr; Prev</button>
+                        <div class="flashcard-progress">${state.flashcard.currentIndex + 1} / ${state.flashcard.deck.length}</div>
+                        <button id="flashcard-next" class="btn-secondary px-3 py-1 rounded-md" ${state.flashcard.currentIndex === state.flashcard.deck.length - 1 ? 'disabled' : ''}>Next &rarr;</button>
+                    </div>
+
+                    <div class="flashcard-scene">
+                        <div class="flashcard" id="flashcard-active">
+                            <div class="flashcard-face flashcard-front">
+                                <h3 class="text-xl font-bold text-center">${currentCard.name}</h3>
+                            </div>
+                            <div class="flashcard-face flashcard-back">
+                                <p class="text-sm text-gray-800 dark:text-gray-200"><strong class="font-semibold">Key Features:</strong> ${currentCard.keyFeatures}</p>
+                                <p class="text-xs font-mono text-gray-600 dark:text-gray-400 mt-3">Source: ${formatSources(currentCard.sources)}</p>
+                            </div>
                         </div>
                     </div>
-                </div>
-            `).join('');
 
-            dom.resultsContent.innerHTML = `<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">${flashcardHTML}</div>`;
+                    <div class="flashcard-actions">
+                        <button id="flashcard-flip" class="btn-primary px-4 py-2 rounded-md">Flip</button>
+                        <button id="flashcard-shuffle" class="btn-secondary px-4 py-2 rounded-md">
+                            ${state.flashcard.isShuffled ? 'Unshuffle' : 'Shuffle'}
+                        </button>
+                    </div>
+                </div>
+            `;
+
+            dom.resultsContent.innerHTML = html;
+            setupFlashcardEventListeners();
+        }
+
+        function setupFlashcardEventListeners() {
+            document.getElementById('flashcard-prev')?.addEventListener('click', () => navigateFlashcard(-1));
+            document.getElementById('flashcard-next')?.addEventListener('click', () => navigateFlashcard(1));
+            document.getElementById('flashcard-flip')?.addEventListener('click', flipFlashcard);
+            document.getElementById('flashcard-shuffle')?.addEventListener('click', shuffleFlashcards);
+            document.getElementById('flashcard-active')?.addEventListener('click', flipFlashcard);
             
-            diagnoses.forEach((_, index) => {
-                const card = document.getElementById(`flashcard-${index}`);
-                if (card) {
-                    card.addEventListener('click', () => card.classList.toggle('is-flipped'));
+            // Add keyboard listeners only when flashcard view is active
+            document.onkeydown = handleFlashcardKeyPress;
+        }
+
+        function handleFlashcardKeyPress(e) {
+            if (state.activeTab !== 'flashcards') return;
+            switch (e.key) {
+                case 'ArrowLeft':
+                    navigateFlashcard(-1);
+                    break;
+                case 'ArrowRight':
+                    navigateFlashcard(1);
+                    break;
+                case ' ': // Space bar
+                    e.preventDefault(); // Prevent page scroll
+                    flipFlashcard();
+                    break;
+            }
+        }
+
+        function navigateFlashcard(direction) {
+            const newIndex = state.flashcard.currentIndex + direction;
+            if (newIndex >= 0 && newIndex < state.flashcard.deck.length) {
+                state.flashcard.currentIndex = newIndex;
+                render(); // Re-render the flashcard view
+            }
+        }
+
+        function flipFlashcard() {
+            document.getElementById('flashcard-active')?.classList.toggle('is-flipped');
+        }
+
+        function shuffleFlashcards() {
+            if (state.flashcard.isShuffled) {
+                // Unshuffle: restore original order
+                const findingData = state.dataMap.get(state.selectedFinding);
+                state.flashcard.deck = findingData.diagnoses.map(dx => ({...dx, finding: state.selectedFinding}));
+            } else {
+                // Shuffle
+                let deck = state.flashcard.deck;
+                for (let i = deck.length - 1; i > 0; i--) {
+                    const j = Math.floor(Math.random() * (i + 1));
+                    [deck[i], deck[j]] = [deck[j], deck[i]];
                 }
-            });
+            }
+            state.flashcard.isShuffled = !state.flashcard.isShuffled;
+            state.flashcard.currentIndex = 0;
+            render();
         }
         
         function renderNetworkView(findingData) {


### PR DESCRIPTION
This commit refactors the flashcards functionality to be more like Anki.

- Only one flashcard is shown at a time.
- Navigation buttons (previous, next) and a progress indicator have been added.
- A shuffle button has been added to randomize the card order.
- The back of the card is no longer visible when viewing the front.
- Keyboard navigation has been added (left/right arrows for navigation, spacebar to flip).
- The CSS for flashcards has been moved to a separate file.