### PR TITLE
fix: Correct CSS path for flashcards

### DIFF
--- a/apps/dermpath ddxs.html
+++ b/apps/dermpath ddxs.html
@@ -14,7 +14,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
 
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="dermatology-study-system/css/flashcards.css">
+    <link rel="stylesheet" href="/apps/dermatology-study-system/css/flashcards.css">
     <style>
         /* Design System using CSS Variables */
         :root {


### PR DESCRIPTION
This commit fixes a bug where the flashcard CSS was not being loaded correctly due to an incorrect path. The path has been updated to an absolute path to ensure it is always loaded correctly.

This resolves the issue where the flashcard content was not laid out correctly and the flip animation was not working.