### PR TITLE
fix: restore app previews

### DIFF
--- a/site/public/assets/apps/dermpath-preview.svg
+++ b/site/public/assets/apps/dermpath-preview.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 600" role="img" aria-labelledby="title" preserveAspectRatio="xMidYMid slice">
+  <title id="title">Dermatopathology Navigator illustrative preview</title>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1d4ed8"/>
+      <stop offset="100%" stop-color="#7c3aed"/>
+    </linearGradient>
+    <linearGradient id="card" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.88)"/>
+      <stop offset="100%" stop-color="rgba(255,255,255,0.72)"/>
+    </linearGradient>
+  </defs>
+  <rect width="960" height="600" fill="url(#bg)"/>
+  <g transform="translate(120 90)">
+    <rect width="720" height="420" rx="32" fill="url(#card)"/>
+    <rect x="48" y="64" width="280" height="48" rx="12" fill="#1d4ed8" opacity="0.15"/>
+    <rect x="48" y="132" width="240" height="20" rx="10" fill="#1d4ed8" opacity="0.4"/>
+    <rect x="48" y="168" width="320" height="20" rx="10" fill="#1d4ed8" opacity="0.25"/>
+    <g transform="translate(420 60)">
+      <circle cx="80" cy="80" r="72" fill="#6366f1" opacity="0.22"/>
+      <circle cx="220" cy="60" r="52" fill="#22d3ee" opacity="0.35"/>
+      <circle cx="160" cy="180" r="44" fill="#38bdf8" opacity="0.3"/>
+      <path d="M36 216c24-44 76-96 124-112 60-20 132 12 188-40" stroke="#312e81" stroke-width="12" stroke-linecap="round" opacity="0.35" fill="none"/>
+    </g>
+    <rect x="48" y="228" width="240" height="44" rx="12" fill="#0ea5e9" opacity="0.18"/>
+    <rect x="48" y="292" width="320" height="44" rx="12" fill="#0ea5e9" opacity="0.12"/>
+    <rect x="48" y="356" width="200" height="20" rx="10" fill="#1e3a8a" opacity="0.35"/>
+  </g>
+</svg>

--- a/site/public/assets/apps/pdf-suite-preview.svg
+++ b/site/public/assets/apps/pdf-suite-preview.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 600" role="img" aria-labelledby="title" preserveAspectRatio="xMidYMid slice">
+  <title id="title">PDF Utility Suite illustrative preview</title>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fb923c"/>
+      <stop offset="100%" stop-color="#ec4899"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0.3" cy="0.3" r="0.9">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.85)"/>
+      <stop offset="100%" stop-color="rgba(255,255,255,0.15)"/>
+    </radialGradient>
+  </defs>
+  <rect width="960" height="600" fill="url(#bg)"/>
+  <g transform="translate(160 110)">
+    <rect width="640" height="380" rx="28" fill="rgba(255,255,255,0.85)"/>
+    <rect x="56" y="72" width="240" height="44" rx="16" fill="#fb923c" opacity="0.18"/>
+    <rect x="320" y="72" width="240" height="44" rx="16" fill="#ec4899" opacity="0.18"/>
+    <rect x="56" y="146" width="504" height="28" rx="14" fill="#fb7185" opacity="0.35"/>
+    <rect x="56" y="190" width="420" height="24" rx="12" fill="#fb7185" opacity="0.24"/>
+    <rect x="56" y="234" width="360" height="24" rx="12" fill="#fb7185" opacity="0.18"/>
+    <rect x="56" y="286" width="504" height="88" rx="20" fill="url(#glow)"/>
+    <path d="M120 316h140l-24 28h140l-24 28h140" stroke="#ec4899" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" opacity="0.5" fill="none"/>
+  </g>
+  <g transform="translate(620 380)">
+    <circle cx="0" cy="0" r="88" fill="rgba(255,255,255,0.14)"/>
+    <path d="M-24 -24h48l24 24-24 24h-48l-24-24z" fill="#f8fafc" opacity="0.45"/>
+    <rect x="-12" y="-54" width="24" height="108" rx="12" fill="#fef2f2" opacity="0.4"/>
+  </g>
+</svg>

--- a/site/public/assets/apps/skinscores-preview.svg
+++ b/site/public/assets/apps/skinscores-preview.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 600" role="img" aria-labelledby="title" preserveAspectRatio="xMidYMid slice">
+  <title id="title">SkinScores interface illustrative preview</title>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="#0ea5e9"/>
+      <stop offset="100%" stop-color="#1e293b"/>
+    </linearGradient>
+    <linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.92)"/>
+      <stop offset="100%" stop-color="rgba(255,255,255,0.78)"/>
+    </linearGradient>
+  </defs>
+  <rect width="960" height="600" fill="url(#bg)"/>
+  <g transform="translate(110 90)">
+    <rect width="520" height="420" rx="28" fill="url(#panel)"/>
+    <rect x="48" y="60" width="320" height="36" rx="12" fill="#0ea5e9" opacity="0.2"/>
+    <rect x="48" y="118" width="420" height="20" rx="10" fill="#0ea5e9" opacity="0.35"/>
+    <rect x="48" y="154" width="300" height="20" rx="10" fill="#0284c7" opacity="0.25"/>
+    <rect x="48" y="208" width="420" height="160" rx="20" fill="#e2f2ff" opacity="0.9"/>
+    <line x1="110" y1="256" x2="370" y2="256" stroke="#0284c7" stroke-width="10" stroke-linecap="round" opacity="0.4"/>
+    <circle cx="120" cy="316" r="26" fill="#38bdf8" opacity="0.45"/>
+    <circle cx="200" cy="320" r="18" fill="#0369a1" opacity="0.4"/>
+    <circle cx="290" cy="308" r="34" fill="#0ea5e9" opacity="0.3"/>
+    <rect x="48" y="392" width="260" height="24" rx="12" fill="#0f172a" opacity="0.45"/>
+  </g>
+  <g transform="translate(660 130)">
+    <rect width="190" height="190" rx="24" fill="rgba(15,23,42,0.35)"/>
+    <path d="M32 148c28-42 62-86 128-86" stroke="#bae6fd" stroke-width="12" stroke-linecap="round" fill="none" opacity="0.55"/>
+    <path d="M48 86c12 24 42 40 88 40" stroke="#bae6fd" stroke-width="12" stroke-linecap="round" fill="none" opacity="0.35"/>
+    <circle cx="56" cy="64" r="22" fill="#38bdf8" opacity="0.55"/>
+    <circle cx="146" cy="52" r="16" fill="#0ea5e9" opacity="0.5"/>
+  </g>
+</svg>

--- a/site/src/components/AppPreview.astro
+++ b/site/src/components/AppPreview.astro
@@ -2,6 +2,7 @@
 const {
   name,
   previewImage,
+  previewUrl,
   accent = ['#0f172a', '#1f2937']
 } = Astro.props;
 const accentColors = Array.isArray(accent) && accent.length ? accent : ['#0f172a', '#1f2937'];
@@ -17,12 +18,20 @@ const gradientStyle = `background: linear-gradient(135deg, ${accentColors[0]}, $
   class:list={{
     'app-preview': true,
     'app-preview--image': Boolean(previewImage),
-    'app-preview--gradient': !previewImage
+    'app-preview--iframe': !previewImage && Boolean(previewUrl),
+    'app-preview--gradient': !previewImage && !previewUrl
   }}
   style={!previewImage ? gradientStyle : undefined}
 >
   {previewImage ? (
     <img src={previewImage} alt={`${name} interface preview`} loading="lazy" decoding="async" />
+  ) : previewUrl ? (
+    <iframe
+      src={previewUrl}
+      title={`${name} preview`}
+      loading="lazy"
+      sandbox="allow-same-origin allow-scripts"
+    ></iframe>
   ) : (
     <span class="app-preview__initials" aria-hidden="true">{initials}</span>
   )}
@@ -47,6 +56,20 @@ const gradientStyle = `background: linear-gradient(135deg, ${accentColors[0]}, $
     height: 100%;
     object-fit: cover;
     display: block;
+  }
+
+  .app-preview--iframe iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+    pointer-events: none;
+    transform: scale(1);
+    transform-origin: top left;
+    transition: transform 200ms ease;
+  }
+
+  .app-preview--iframe:hover iframe {
+    transform: scale(1.02);
   }
 
   .app-preview__initials {

--- a/site/src/pages/apps/index.astro
+++ b/site/src/pages/apps/index.astro
@@ -22,7 +22,7 @@ const archived = apps.filter((app) => app.status === 'legacy');
             <div class="app-showcase-card" data-app-tilt>
               <div class={`app-showcase-row ${index % 2 === 1 ? 'app-showcase-row--reverse' : ''}`} data-app-tilt-target>
                 <div class="app-showcase-media">
-                  <AppPreview name={app.name} previewImage={app.previewImage} accent={app.accent} />
+                  <AppPreview name={app.name} previewImage={app.previewImage} previewUrl={app.preview} accent={app.accent} />
                 </div>
                 <div class="app-showcase-body">
                   <span class={`app-showcase-badge app-showcase-badge--${app.status}`}>{app.status === 'beta' ? 'In Beta' : 'Active'}</span>


### PR DESCRIPTION
## Summary
- render live iframes when no static preview image is available so each app listing shows its UI again
- supply new svg snapshots for DermPath, SkinScores, and PDF Suite
- keep the gradient fallback only for apps without an accessible preview

## Testing
- npm --prefix site run build