### PR TITLE
style: align header logo with favicon

### DIFF
--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -121,16 +121,19 @@ main {
 .header-logo {
   display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.65rem;
   font-family: var(--font-display);
-  font-size: 1.08rem;
+  font-size: 1.05rem;
   color: var(--text-color);
   letter-spacing: 0.04em;
+  padding: 0;
 }
 
 .header-logo img {
-  border-radius: 12px;
-  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.15);
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  box-shadow: none;
 }
 
 .header-nav {


### PR DESCRIPTION
## Summary
- adjust header logo styling so the favicon renders at its original size without the white pill

## Testing
- npm --prefix site run build