### PR TITLE
feat: publish abc news and medscape bylines

### DIFF
--- a/site/src/components/Header.jsx
+++ b/site/src/components/Header.jsx
@@ -60,7 +60,7 @@ const Header = () => {
     <header className="header-shell" data-scroll-fade>
       <div className="header-inner">
         <a href="/" aria-label="Ramie Fathy home" className="header-logo">
-          <img src="/favicon.svg" width="36" height="36" alt="Ramie Fathy logo" />
+          <img src="/favicon.ico" width="32" height="32" alt="Ramie Fathy logo" />
           <span>Ramie Fathy, MD</span>
         </a>
         <nav className="header-nav" aria-label="Primary navigation">

--- a/site/src/data/blog.json
+++ b/site/src/data/blog.json
@@ -1,23 +1,51 @@
 [
   {
-    "title": "AI in Dermatology: Opportunities and Guardrails",
-    "date": "2025-08-12",
-    "summary": "Key considerations for deploying generative AI tools within clinic workflows, based on current fellowship research.",
-    "href": "https://www.medscape.com/viewarticle/1234567",
-    "tags": ["AI", "Clinical Informatics", "Commentary"]
+    "title": "From Unmatched to Top Pick: Highs and Lows of a Year in Limbo",
+    "date": "2022-04-20",
+    "summary": "Reflections on resilience, mentorship, and growth during the year between match cycles.",
+    "href": "https://www.medscape.com/viewarticle/972199",
+    "tags": ["Career", "Medscape", "Opinion"]
   },
   {
-    "title": "When Rheumatology Meets Dermatology",
-    "date": "2025-05-04",
-    "summary": "Navigating multi-system autoimmune disease with a joint rheumatology-dermatology lens and case-based pearls.",
-    "href": "https://abcnews.go.com/Health/skin-autoimmune-collaboration",
-    "tags": ["Autoimmune", "Education"]
+    "title": "5 things to know about COVID-19 vaccines",
+    "date": "2020-12-14",
+    "summary": "Explaining early Pfizer and Moderna efficacy data and what deployment means for patients.",
+    "href": "https://abcnews.go.com/Health/things-covid-19-vaccines/story?id=74591998",
+    "tags": ["COVID-19", "ABC News", "Public Health"]
   },
   {
-    "title": "Designing Resident-Friendly Digital Tools",
-    "date": "2025-02-18",
-    "summary": "Principles guiding the development of calculators, checklists, and navigators that fit into high-acuity inpatient consults.",
-    "href": "https://ramiefathy.github.io/apps",
-    "tags": ["Product", "Residents"]
+    "title": "From wildfires to disease, here are the top 5 ways climate change is already hurting your health",
+    "date": "2020-11-25",
+    "summary": "Climate-linked hazards—from smoke exposure to vector-borne disease—are reshaping dermatologic health.",
+    "href": "https://abcnews.go.com/Health/wildfires-disease-top-ways-climate-change-hurting-health/story?id=74324763",
+    "tags": ["Climate", "ABC News", "Health Equity"]
+  },
+  {
+    "title": "Experts express concerns about possible coronavirus transmission at vice president debate",
+    "date": "2020-10-07",
+    "summary": "Why plexiglass alone could not guarantee safety on the 2020 vice presidential debate stage.",
+    "href": "https://abcnews.go.com/Health/experts-express-concerns-coronavirus-transmission-vice-president-debate/story?id=73451239",
+    "tags": ["COVID-19", "ABC News", "Policy"]
+  },
+  {
+    "title": "Med Students and Doctors Shouldn't Sell Advice",
+    "date": "2020-07-29",
+    "summary": "A call for ethical boundaries as premed advising companies court medical trainees.",
+    "href": "https://www.medscape.com/viewarticle/934573",
+    "tags": ["Ethics", "Medscape", "Education"]
+  },
+  {
+    "title": "A Dangerous 'Diagnosis': New Netflix Series May Do Harm",
+    "date": "2019-10-04",
+    "summary": "Examining how televised crowdsourcing of rare cases could undermine trust in bedside diagnostics.",
+    "href": "https://www.medscape.com/viewarticle/919202",
+    "tags": ["Media", "Medscape", "Diagnostics"]
+  },
+  {
+    "title": "No, Practicing Medicine Is Not Just About Basic Biology",
+    "date": "2019-09-20",
+    "summary": "Highlighting the social determinants of health every clinician must learn to navigate.",
+    "href": "https://www.medscape.com/viewarticle/918793",
+    "tags": ["Health Equity", "Medscape", "Opinion"]
   }
 ]


### PR DESCRIPTION
## Summary
- update blog data with published ABC News and Medscape features (titles, summaries, dates, tags)
- swap site favicon in the header to match the browser tab icon provided by the author

## Testing
- npm --prefix site run build