### PR TITLE
feat: refine entry expand UX and add risk tooltips

### DIFF
--- a/apps/biologic-monitoring-dashboard/app.js
+++ b/apps/biologic-monitoring-dashboard/app.js
@@ -24,6 +24,21 @@ const riskBadgeConfig = {
   infection: { icon: '🦠', className: 'badge-infection' }
 };
 
+const riskBadgeDescriptions = {
+  'boxed-warning':
+    'FDA boxed warning present – review prescribing information for life-threatening risks, monitoring, and contraindications before prescribing.',
+  teratogenic:
+    'Teratogenic risk – requires strict pregnancy prevention, counseling, and testing per regimen guidelines.',
+  rems:
+    'REMS program required – enrollment and compliance with Risk Evaluation and Mitigation Strategy are mandatory.',
+  'age-65-plus':
+    'Higher risk in patients aged 65 and older – evaluate cardiovascular, malignancy, and infection risks closely.',
+  pediatric:
+    'Pediatric-specific considerations – dosing, safety, or monitoring differs in children and adolescents.',
+  infection:
+    'Elevated serious infection risk – ensure screening, vaccination, and patient counseling on early symptom reporting.'
+};
+
 const STORAGE_KEYS = {
   favorites: 'biologic-dashboard:favorites',
   recent: 'biologic-dashboard:recent',
@@ -100,6 +115,14 @@ function buildFilterOptions(values, labelMap) {
   return values
     .map((value) => ({ id: value, label: labelMap[value] || toTitleCase(value) }))
     .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+function escapeAttribute(value = '') {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
 }
 
 function loadSet(key) {
@@ -303,7 +326,10 @@ function buildRiskIndicators(entry) {
     .map((flag) => {
       const config = riskBadgeConfig[flag] || { icon: '⚠️', className: 'badge-generic' };
       const label = RISK_BADGE_LABELS[flag] || toTitleCase(flag);
-      return `<span class="risk-badge ${config.className}" title="${label}">${config.icon} ${label}</span>`;
+      const description = riskBadgeDescriptions[flag] || 'Review prescribing information for additional safety guidance.';
+      return `<span class="risk-badge ${config.className}" tabindex="0" data-tooltip="${escapeAttribute(
+        description
+      )}" aria-label="${escapeAttribute(description)}">${config.icon} <span class="risk-badge__text">${label}</span></span>`;
     })
     .join('');
   return `<div class="risk-indicators">${badges}</div>`;
@@ -513,9 +539,6 @@ function renderEntryCard(entry, query) {
               <span aria-hidden="true">⇄</span>
               <span class="sr-only">${isCompared ? 'Remove from comparison' : 'Add to comparison'}</span>
             </button>
-            <button class="expand-btn" type="button" data-action="toggle-details" data-entry-id="${entry.id}" aria-expanded="${isExpanded}">
-              ${isExpanded ? 'Hide details' : 'View details'}
-            </button>
           </div>
         </div>
       </header>
@@ -525,6 +548,12 @@ function renderEntryCard(entry, query) {
           <p class="agent-list">${highlightText(entry.agents.join(', '), query)}</p>
         </div>
         ${buildMetaChips(entry)}
+      </div>
+      <div class="entry-toggle">
+        <button class="expand-btn" type="button" data-action="toggle-details" data-entry-id="${entry.id}" aria-expanded="${isExpanded}">
+          <span class="expand-btn__label">${isExpanded ? 'Hide monitoring details' : 'View monitoring details'}</span>
+          <span class="expand-btn__icon" aria-hidden="true">${isExpanded ? '▴' : '▾'}</span>
+        </button>
       </div>
       <div class="entry-details ${isExpanded ? 'is-open' : ''}" data-entry-details="${entry.id}" aria-hidden="${!isExpanded}">
         <div class="detail-tabs" role="tablist">

--- a/apps/biologic-monitoring-dashboard/styles.css
+++ b/apps/biologic-monitoring-dashboard/styles.css
@@ -437,6 +437,7 @@ small {
 .meta-actions {
   display: flex;
   gap: 8px;
+  justify-content: flex-end;
 }
 
 .icon-btn {
@@ -616,6 +617,80 @@ small {
 
 .entry-details.is-open {
   display: grid;
+}
+
+.entry-toggle {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: -8px;
+}
+
+.expand-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.14);
+  background: rgba(255, 255, 255, 0.85);
+  color: var(--accent);
+  cursor: pointer;
+  font-weight: 600;
+  transition: all 140ms ease;
+}
+
+.expand-btn:hover,
+.expand-btn:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+
+.expand-btn[aria-expanded='true'] {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 0 12px 22px rgba(37, 99, 235, 0.22);
+}
+
+.expand-btn__icon {
+  font-size: 0.85rem;
+}
+
+.risk-badge {
+  position: relative;
+  cursor: default;
+}
+
+.risk-badge:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.risk-badge::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 50%;
+  top: calc(100% + 10px);
+  transform: translateX(-50%);
+  background: rgba(15, 23, 42, 0.95);
+  color: #fff;
+  padding: 8px 12px;
+  border-radius: 8px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.4;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.22);
+  max-width: 280px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 140ms ease, transform 140ms ease;
+  transform-origin: top center;
+  z-index: 5;
+}
+
+.risk-badge:hover::after,
+.risk-badge:focus::after {
+  opacity: 1;
+  transform: translate(-50%, 0);
 }
 
 .detail-tabs {

--- a/site/public/apps/biologic-monitoring-dashboard/app.js
+++ b/site/public/apps/biologic-monitoring-dashboard/app.js
@@ -24,6 +24,21 @@ const riskBadgeConfig = {
   infection: { icon: '🦠', className: 'badge-infection' }
 };
 
+const riskBadgeDescriptions = {
+  'boxed-warning':
+    'FDA boxed warning present – review prescribing information for life-threatening risks, monitoring, and contraindications before prescribing.',
+  teratogenic:
+    'Teratogenic risk – requires strict pregnancy prevention, counseling, and testing per regimen guidelines.',
+  rems:
+    'REMS program required – enrollment and compliance with Risk Evaluation and Mitigation Strategy are mandatory.',
+  'age-65-plus':
+    'Higher risk in patients aged 65 and older – evaluate cardiovascular, malignancy, and infection risks closely.',
+  pediatric:
+    'Pediatric-specific considerations – dosing, safety, or monitoring differs in children and adolescents.',
+  infection:
+    'Elevated serious infection risk – ensure screening, vaccination, and patient counseling on early symptom reporting.'
+};
+
 const STORAGE_KEYS = {
   favorites: 'biologic-dashboard:favorites',
   recent: 'biologic-dashboard:recent',
@@ -100,6 +115,14 @@ function buildFilterOptions(values, labelMap) {
   return values
     .map((value) => ({ id: value, label: labelMap[value] || toTitleCase(value) }))
     .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+function escapeAttribute(value = '') {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
 }
 
 function loadSet(key) {
@@ -303,7 +326,10 @@ function buildRiskIndicators(entry) {
     .map((flag) => {
       const config = riskBadgeConfig[flag] || { icon: '⚠️', className: 'badge-generic' };
       const label = RISK_BADGE_LABELS[flag] || toTitleCase(flag);
-      return `<span class="risk-badge ${config.className}" title="${label}">${config.icon} ${label}</span>`;
+      const description = riskBadgeDescriptions[flag] || 'Review prescribing information for additional safety guidance.';
+      return `<span class="risk-badge ${config.className}" tabindex="0" data-tooltip="${escapeAttribute(
+        description
+      )}" aria-label="${escapeAttribute(description)}">${config.icon} <span class="risk-badge__text">${label}</span></span>`;
     })
     .join('');
   return `<div class="risk-indicators">${badges}</div>`;
@@ -513,9 +539,6 @@ function renderEntryCard(entry, query) {
               <span aria-hidden="true">⇄</span>
               <span class="sr-only">${isCompared ? 'Remove from comparison' : 'Add to comparison'}</span>
             </button>
-            <button class="expand-btn" type="button" data-action="toggle-details" data-entry-id="${entry.id}" aria-expanded="${isExpanded}">
-              ${isExpanded ? 'Hide details' : 'View details'}
-            </button>
           </div>
         </div>
       </header>
@@ -525,6 +548,12 @@ function renderEntryCard(entry, query) {
           <p class="agent-list">${highlightText(entry.agents.join(', '), query)}</p>
         </div>
         ${buildMetaChips(entry)}
+      </div>
+      <div class="entry-toggle">
+        <button class="expand-btn" type="button" data-action="toggle-details" data-entry-id="${entry.id}" aria-expanded="${isExpanded}">
+          <span class="expand-btn__label">${isExpanded ? 'Hide monitoring details' : 'View monitoring details'}</span>
+          <span class="expand-btn__icon" aria-hidden="true">${isExpanded ? '▴' : '▾'}</span>
+        </button>
       </div>
       <div class="entry-details ${isExpanded ? 'is-open' : ''}" data-entry-details="${entry.id}" aria-hidden="${!isExpanded}">
         <div class="detail-tabs" role="tablist">

--- a/site/public/apps/biologic-monitoring-dashboard/styles.css
+++ b/site/public/apps/biologic-monitoring-dashboard/styles.css
@@ -437,6 +437,7 @@ small {
 .meta-actions {
   display: flex;
   gap: 8px;
+  justify-content: flex-end;
 }
 
 .icon-btn {
@@ -616,6 +617,80 @@ small {
 
 .entry-details.is-open {
   display: grid;
+}
+
+.entry-toggle {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: -8px;
+}
+
+.expand-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.14);
+  background: rgba(255, 255, 255, 0.85);
+  color: var(--accent);
+  cursor: pointer;
+  font-weight: 600;
+  transition: all 140ms ease;
+}
+
+.expand-btn:hover,
+.expand-btn:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+
+.expand-btn[aria-expanded='true'] {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 0 12px 22px rgba(37, 99, 235, 0.22);
+}
+
+.expand-btn__icon {
+  font-size: 0.85rem;
+}
+
+.risk-badge {
+  position: relative;
+  cursor: default;
+}
+
+.risk-badge:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.risk-badge::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 50%;
+  top: calc(100% + 10px);
+  transform: translateX(-50%);
+  background: rgba(15, 23, 42, 0.95);
+  color: #fff;
+  padding: 8px 12px;
+  border-radius: 8px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.4;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.22);
+  max-width: 280px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 140ms ease, transform 140ms ease;
+  transform-origin: top center;
+  z-index: 5;
+}
+
+.risk-badge:hover::after,
+.risk-badge:focus::after {
+  opacity: 1;
+  transform: translate(-50%, 0);
 }
 
 .detail-tabs {


### PR DESCRIPTION
## Summary
- replace empty action slot with a single detail toggle for each regimen card
- add accessible hover/focus tooltips explaining each risk indicator badge
- update site bundle with alignments and expand button styling

## Testing
- npm run site:build