### PR TITLE
feat: elevate export action to card header

### DIFF
--- a/apps/biologic-monitoring-dashboard/app.js
+++ b/apps/biologic-monitoring-dashboard/app.js
@@ -539,6 +539,7 @@ function renderEntryCard(entry, query) {
               <span aria-hidden="true">⇄</span>
               <span class="sr-only">${isCompared ? 'Remove from comparison' : 'Add to comparison'}</span>
             </button>
+            <button class="secondary-btn export-btn" type="button" data-action="export-checklist" data-entry-id="${entry.id}">Export checklist</button>
           </div>
         </div>
       </header>
@@ -585,7 +586,6 @@ function renderEntryCard(entry, query) {
           ${buildReferences(entry)}
           <div class="entry-actions">
             <button class="copy-btn" type="button" data-action="copy" data-entry-id="${entry.id}">${COPY_BUTTON_LABEL}</button>
-            <button class="secondary-btn export-btn" type="button" data-action="export-checklist" data-entry-id="${entry.id}">Export checklist</button>
           </div>
         </div>
       </div>

--- a/apps/biologic-monitoring-dashboard/styles.css
+++ b/apps/biologic-monitoring-dashboard/styles.css
@@ -444,6 +444,7 @@ small {
   display: flex;
   gap: 8px;
   justify-content: flex-end;
+  flex-wrap: wrap;
 }
 
 .icon-btn {

--- a/site/public/apps/biologic-monitoring-dashboard/app.js
+++ b/site/public/apps/biologic-monitoring-dashboard/app.js
@@ -539,6 +539,7 @@ function renderEntryCard(entry, query) {
               <span aria-hidden="true">⇄</span>
               <span class="sr-only">${isCompared ? 'Remove from comparison' : 'Add to comparison'}</span>
             </button>
+            <button class="secondary-btn export-btn" type="button" data-action="export-checklist" data-entry-id="${entry.id}">Export checklist</button>
           </div>
         </div>
       </header>
@@ -585,7 +586,6 @@ function renderEntryCard(entry, query) {
           ${buildReferences(entry)}
           <div class="entry-actions">
             <button class="copy-btn" type="button" data-action="copy" data-entry-id="${entry.id}">${COPY_BUTTON_LABEL}</button>
-            <button class="secondary-btn export-btn" type="button" data-action="export-checklist" data-entry-id="${entry.id}">Export checklist</button>
           </div>
         </div>
       </div>

--- a/site/public/apps/biologic-monitoring-dashboard/styles.css
+++ b/site/public/apps/biologic-monitoring-dashboard/styles.css
@@ -444,6 +444,7 @@ small {
   display: flex;
   gap: 8px;
   justify-content: flex-end;
+  flex-wrap: wrap;
 }
 
 .icon-btn {


### PR DESCRIPTION
## Summary
- move export checklist action into card header next to favorite/compare controls
- keep only copy button inside expanded monitoring footer for clarity
- sync updated stylesheet into published bundle

## Testing
- npm run site:build