### PR TITLE
fix: address PR review comments

### DIFF
--- a/site/public/tasks/index.html
+++ b/site/public/tasks/index.html
@@ -439,6 +439,11 @@ body{font-family:var(--font);background:var(--bg);color:var(--text);line-height:
 const COLORS=['#6B8F71','#C17C74','#C4973B','#7B8DB5','#9B7EBD','#D4915B','#5B9EA6','#B5725F','#8B9862','#C48B9F'];
 let S={tasks:[],projects:[],view:'dashboard',sel:new Set(),editId:null,editProjIdx:null,cfCb:null,sortF:'createdAt',sortD:-1,selColor:COLORS[0],projFilter:null,calEvents:[]};
 
+const LOGIN_BUTTON_DEFAULT_HTML = (() => {
+  const btn = document.getElementById('login-btn')
+  return btn ? btn.innerHTML : 'Sign in with Google'
+})()
+
 // ===== FIREBASE SYNC + AUTH =====
 const FB_CONFIG = {
   apiKey: "AIzaSyC1KojeBcYQSurott2XHDWpYjwIpgrtqY0",
@@ -487,7 +492,7 @@ function signIn() {
 
   firebase.auth().signInWithPopup(provider).catch((err) => {
     btn.disabled = false;
-    btn.innerHTML = '<svg viewBox="0 0 24 24"><path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/><path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/><path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/><path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/></svg> Sign in with Google';
+    btn.innerHTML = LOGIN_BUTTON_DEFAULT_HTML;
     if (err.code !== 'auth/popup-closed-by-user') {
       showLoginError(err.message);
     }
@@ -503,6 +508,11 @@ function signOut() {
 function showLogin() {
   document.getElementById('login-screen').style.display = 'flex';
   document.getElementById('app').style.display = 'none';
+
+  const btn = document.getElementById('login-btn');
+  btn.disabled = false;
+  btn.innerHTML = LOGIN_BUTTON_DEFAULT_HTML;
+  document.getElementById('login-err').style.display = 'none';
 }
 
 function showApp(user) {

--- a/site/public/tasks/index.html
+++ b/site/public/tasks/index.html
@@ -444,6 +444,8 @@ const LOGIN_BUTTON_DEFAULT_HTML = (() => {
   return btn ? btn.innerHTML : 'Sign in with Google'
 })()
 
+let preserveLoginErrorOnce = false;
+
 // ===== FIREBASE SYNC + AUTH =====
 const FB_CONFIG = {
   apiKey: "AIzaSyC1KojeBcYQSurott2XHDWpYjwIpgrtqY0",
@@ -512,7 +514,14 @@ function showLogin() {
   const btn = document.getElementById('login-btn');
   btn.disabled = false;
   btn.innerHTML = LOGIN_BUTTON_DEFAULT_HTML;
-  document.getElementById('login-err').style.display = 'none';
+
+  const err = document.getElementById('login-err');
+  if (preserveLoginErrorOnce) {
+    preserveLoginErrorOnce = false;
+  } else {
+    err.style.display = 'none';
+    err.textContent = '';
+  }
 }
 
 function showApp(user) {
@@ -566,6 +575,7 @@ function showApp(user) {
 
 function showLoginError(msg) {
   const el = document.getElementById('login-err');
+  preserveLoginErrorOnce = true;
   el.textContent = msg;
   el.style.display = 'block';
 }

--- a/site/src/security/frontend-design-contract.test.ts
+++ b/site/src/security/frontend-design-contract.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -46,8 +47,8 @@ function walkFiles(rootDir: string, options: WalkOptions): string[] {
     if (!currentDir) continue
 
     const rel = path.relative(rootDir, currentDir)
-    const firstSegment = rel.split(path.sep)[0]
-    if (firstSegment && options.excludeDirs.includes(firstSegment)) continue
+    const segments = rel.split(path.sep).filter(Boolean)
+    if (segments.some((segment) => options.excludeDirs.includes(segment))) continue
 
     const entries = fs.readdirSync(currentDir, { withFileTypes: true })
     for (const entry of entries) {
@@ -148,6 +149,29 @@ function hexToHue(hex: string): number {
 }
 
 describe('Frontend Design System Contract (legacy apps)', () => {
+  it('walkFiles excludes vendor directories recursively', () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'frontend-contract-walk-'))
+    try {
+      const nestedVendorDir = path.join(rootDir, 'app-one', 'vendor', 'nested')
+      fs.mkdirSync(nestedVendorDir, { recursive: true })
+      fs.writeFileSync(path.join(nestedVendorDir, 'bundle.js'), 'Inter', 'utf-8')
+
+      const okDir = path.join(rootDir, 'app-one', 'src')
+      fs.mkdirSync(okDir, { recursive: true })
+      fs.writeFileSync(path.join(okDir, 'main.js'), 'console.log("ok")', 'utf-8')
+
+      const files = walkFiles(rootDir, {
+        excludeDirs: ['vendor'],
+        excludeFilePatterns: [],
+        includeExtensions: new Set(['.js'])
+      }).map((filePath) => path.relative(rootDir, filePath)).sort()
+
+      expect(files).toEqual(['app-one/src/main.js'])
+    } finally {
+      fs.rmSync(rootDir, { recursive: true, force: true })
+    }
+  })
+
   it('legacy shared tokens define required semantic variables', () => {
     const tokensPath = path.join(SHARED_ROOT, 'legacy-tokens.css')
     const css = fs.readFileSync(tokensPath, 'utf-8')

--- a/site/src/security/taskboard-login-reset.test.ts
+++ b/site/src/security/taskboard-login-reset.test.ts
@@ -33,4 +33,21 @@ describe('Taskboard login flow contract', () => {
     expect(signInBlock).toBeDefined()
     expect(signInBlock).toMatch(/btn\.innerHTML\s*=\s*LOGIN_BUTTON_DEFAULT_HTML/)
   })
+
+  it('preserves access-denied login error through auth sign-out callback', () => {
+    const html = fs.readFileSync(TASKBOARD_PATH, 'utf-8')
+    const script = getInlineScript(html)
+
+    const showLoginBlock = script.match(/function\s+showLogin\(\)\s*\{[\s\S]*?\n\}/)?.[0]
+    expect(showLoginBlock).toBeDefined()
+
+    const showLoginErrorBlock = script.match(/function\s+showLoginError\([^)]*\)\s*\{[\s\S]*?\n\}/)?.[0]
+    expect(showLoginErrorBlock).toBeDefined()
+
+    expect(script).toContain('preserveLoginErrorOnce')
+    expect(showLoginErrorBlock).toMatch(/preserveLoginErrorOnce\s*=\s*true/)
+    expect(showLoginBlock).toMatch(/if\s*\(\s*preserveLoginErrorOnce\s*\)/)
+    expect(showLoginBlock).toMatch(/else[\s\S]*err\.style\.display\s*=\s*['"]none['"]/i)
+    expect(showLoginBlock).toMatch(/else[\s\S]*err\.textContent\s*=\s*['"]{0,1}['"]{0,1}\s*;/i)
+  })
 })

--- a/site/src/security/taskboard-login-reset.test.ts
+++ b/site/src/security/taskboard-login-reset.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const SITE_ROOT = path.resolve(__dirname, '../..')
+
+const TASKBOARD_PATH = path.resolve(SITE_ROOT, 'public', 'tasks', 'index.html')
+
+function getInlineScript(html: string): string {
+  const match = html.match(/<script>([\s\S]*?)<\/script>/i)
+  if (!match) {
+    throw new Error(`Unable to find inline <script> in ${TASKBOARD_PATH}`)
+  }
+  return match[1]
+}
+
+describe('Taskboard login flow contract', () => {
+  it('showLogin() restores login button state after sign-out', () => {
+    const html = fs.readFileSync(TASKBOARD_PATH, 'utf-8')
+    const script = getInlineScript(html)
+
+    expect(script).toContain('LOGIN_BUTTON_DEFAULT_HTML')
+    expect(script).toMatch(/function\s+showLogin\(\)\s*\{[\s\S]*btn\.disabled\s*=\s*false/i)
+
+    const showLoginBlock = script.match(/function\s+showLogin\(\)\s*\{[\s\S]*?\n\}/)?.[0]
+    expect(showLoginBlock).toBeDefined()
+    expect(showLoginBlock).toMatch(/btn\.innerHTML\s*=\s*LOGIN_BUTTON_DEFAULT_HTML/)
+
+    const signInBlock = script.match(/function\s+signIn\(\)\s*\{[\s\S]*?\n\}/)?.[0]
+    expect(signInBlock).toBeDefined()
+    expect(signInBlock).toMatch(/btn\.innerHTML\s*=\s*LOGIN_BUTTON_DEFAULT_HTML/)
+  })
+})


### PR DESCRIPTION
Follow-up for inline review comments on:\n- #104 (Taskboard): restore login button state on sign-out\n- #102 (design-contract test): skip nested vendor directories recursively\n\nChanges:\n- Reset login button disabled/label in `showLogin()` and dedupe the default button HTML.\n- Fix directory walker to exclude any nested `vendor` dir, and add a regression test.\n- Add a small contract test to prevent Taskboard login regression.\n\nVerification:\n- `npm --prefix site test`\n- `npm --prefix site run build`\n