### PR TITLE
agent(claude-code): unlist KSA Sovereign Credit Analytics from /apps

### DIFF
--- a/site/src/data/apps.json
+++ b/site/src/data/apps.json
@@ -83,6 +83,7 @@
     "slug": "ksa-sovereign-credit-analytics",
     "description": "Private source-aware sovereign credit dashboard for Saudi Eurobond, CDS, and benchmark monitoring, deployed behind Cloudflare Access with licensed live feeds managed separately.",
     "status": "active",
+    "listed": false,
     "stack": [
       "Cloudflare Access",
       "Docker",

--- a/site/src/pages/apps/index.astro
+++ b/site/src/pages/apps/index.astro
@@ -26,7 +26,11 @@ const CATEGORY_LABELS: Record<string, string> = {
   productivity: 'Productivity'
 };
 
-const active = apps.filter((app) => app.status === 'active');
+// Filter to active apps that are also publicly listed.
+// Set `"listed": false` on an apps.json entry to keep the data record but hide it
+// from the catalog (e.g., private dashboards still hosted at a subdomain but not
+// advertised on the public site).
+const active = apps.filter((app) => app.status === 'active' && app.listed !== false);
 const enriched = active.map((app, idx) => ({
   ...app,
   plateNumber: `III.${String(idx + 1).padStart(2, '0')}`,


### PR DESCRIPTION
## Summary

Hide the KSA Sovereign Credit Analytics dashboard from the public `/apps` catalog without deleting it. The app remains hosted at `https://ksa-credit.ramiefathy.com/` behind Cloudflare Access; the only change here is that ramiefathy.com no longer advertises it.

Mechanism: a new `"listed": false` flag on the `apps.json` entry, and a corresponding filter update in `site/src/pages/apps/index.astro`.

## Why this matters

- KSA Credit is `status: "active"` (the dashboard is live) but is not appropriate to surface in a public dermatology/AI portfolio.
- `status: "legacy"` (the existing hide mechanism per [docs/app-redesign-specs.md](docs/app-redesign-specs.md) Spec 1) doesn't fit — the app isn't legacy, it's just private.
- `listed: false` cleanly separates "is this app maintained?" from "should it appear in the public catalog?"

## Test plan

- [x] `npm run site:test` — all 212 Vitest tests pass
- [x] Verified KSA's `apps.json` entry retains its data (slug, description, stack, accent, etc.) — only `listed: false` added
- [ ] CI green on push (build-site, e2e-playwright, ai-scribe-lint)
- [ ] Visual confirmation on deploy preview: `/apps` shows 9 catalog entries (was 10), filter counts decrement appropriately

## Notes

- The flag is generic. Future apps that should exist in the data but not be advertised can use the same pattern.
- Filter counts (`All / Featured / Clinical / Learning / Reference / Productivity`) update automatically because they iterate over the already-filtered `enriched` array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * KSA Sovereign Credit Analytics application has been removed from the public app catalog.
  * The apps listing now filters applications by active status and public listing designation to control visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramiefathy/ramiefathy.github.io/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->