### PR TITLE
Add verifiable master CI and production deployment gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+  statuses: write
+
 jobs:
   build-site:
     runs-on: ubuntu-latest
@@ -41,7 +45,6 @@ jobs:
           path: site/public/apps/rheum-derm-clinical-trials
           if-no-files-found: error
           retention-days: 1
-      # Removed Playwright console regression checks; they are run locally as needed
 
   e2e-playwright:
     runs-on: ubuntu-latest
@@ -79,3 +82,42 @@ jobs:
         run: python -m compileall services/ai-scribe
       - name: Run backend tests
         run: python -m pytest services/ai-scribe/tests -q
+
+  report-master-ci-status:
+    if: ${{ always() && github.event_name == 'push' }}
+    needs:
+      - build-site
+      - e2e-playwright
+      - ai-scribe-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish combined master CI status
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD_RESULT: ${{ needs.build-site.result }}
+          E2E_RESULT: ${{ needs.e2e-playwright.result }}
+          SCRIBE_RESULT: ${{ needs.ai-scribe-lint.result }}
+        run: |
+          set -euo pipefail
+
+          state=failure
+          description="Master CI failed"
+          if [[ "$BUILD_RESULT" == "success" && "$E2E_RESULT" == "success" && "$SCRIBE_RESULT" == "success" ]]; then
+            state=success
+            description="Build, Playwright, and scribe checks passed"
+          fi
+
+          payload=$(jq -n \
+            --arg state "$state" \
+            --arg target_url "https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}" \
+            --arg description "$description" \
+            --arg context "ci/master" \
+            '{state: $state, target_url: $target_url, description: $description, context: $context}')
+
+          curl --fail-with-body --silent --show-error --location \
+            --request POST \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
+            --data "$payload"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,6 +14,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  statuses: write
 
 jobs:
   build:
@@ -45,3 +46,90 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deploy
         uses: actions/deploy-pages@v4
+
+      - name: Verify the production D&D console
+        id: smoke
+        env:
+          DND_URL: https://ramiefathy.com/tools/dnd-l20-console-f2c7a9/
+        run: |
+          set -u
+
+          index_file="${RUNNER_TEMP}/dnd-index.html"
+          boot_file="${RUNNER_TEMP}/dnd-boot.js"
+          payload_file="${RUNNER_TEMP}/dnd-payload.js"
+
+          for attempt in $(seq 1 30); do
+            cache_key="${GITHUB_SHA}-${attempt}"
+
+            if index_code=$(curl --silent --show-error --location \
+              --connect-timeout 15 --max-time 30 \
+              --output "$index_file" --write-out '%{http_code}' \
+              "${DND_URL}?deploy=${cache_key}"); then :; else index_code=000; fi
+
+            if boot_code=$(curl --silent --show-error --location \
+              --connect-timeout 15 --max-time 30 \
+              --output "$boot_file" --write-out '%{http_code}' \
+              "${DND_URL}boot.js?deploy=${cache_key}"); then :; else boot_code=000; fi
+
+            if payload_code=$(curl --silent --show-error --location \
+              --connect-timeout 15 --max-time 30 \
+              --output "$payload_file" --write-out '%{http_code}' \
+              "${DND_URL}payload-01.js?deploy=${cache_key}"); then :; else payload_code=000; fi
+
+            if [[ "$index_code" == "200" && "$boot_code" == "200" && "$payload_code" == "200" ]] \
+              && grep --fixed-strings --quiet '<title>Level 20 Character Console</title>' "$index_file" \
+              && grep --fixed-strings --quiet 'payload-01.js' "$index_file" \
+              && grep --fixed-strings --quiet 'boot.js' "$index_file" \
+              && grep --fixed-strings --quiet 'DecompressionStream' "$boot_file" \
+              && grep --fixed-strings --quiet 'window.__DND_PAYLOAD' "$payload_file"; then
+              echo "Production smoke test passed on attempt ${attempt}."
+              echo "Index, boot loader, and payload all returned HTTP 200 with expected content."
+              exit 0
+            fi
+
+            echo "Attempt ${attempt}/30 not ready: index=${index_code}, boot=${boot_code}, payload=${payload_code}"
+            sleep 10
+          done
+
+          echo "Production D&D console did not pass the smoke test after 5 minutes."
+          echo "Index response preview:"
+          head -c 500 "$index_file" 2>/dev/null || true
+          exit 1
+
+  report-production-status:
+    if: ${{ always() }}
+    needs:
+      - build
+      - deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish Pages deployment status
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          DEPLOY_RESULT: ${{ needs.deploy.result }}
+          DND_URL: https://ramiefathy.com/tools/dnd-l20-console-f2c7a9/
+        run: |
+          set -euo pipefail
+
+          state=failure
+          description="Pages build, deploy, or live smoke test failed"
+          if [[ "$BUILD_RESULT" == "success" && "$DEPLOY_RESULT" == "success" ]]; then
+            state=success
+            description="Pages deploy and live D&D smoke test passed"
+          fi
+
+          payload=$(jq -n \
+            --arg state "$state" \
+            --arg target_url "$DND_URL" \
+            --arg description "$description" \
+            --arg context "deploy/pages-production" \
+            '{state: $state, target_url: $target_url, description: $description, context: $context}')
+
+          curl --fail-with-body --silent --show-error --location \
+            --request POST \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
+            --data "$payload"


### PR DESCRIPTION
## Purpose

Prevent another premature deployment claim by making both master CI and production publication machine-verifiable.

## Changes

- Publish `ci/master` after the master build, Playwright, and AI-scribe jobs complete.
- After GitHub Pages deployment, retry the live custom-domain URL for up to five minutes.
- Require HTTP 200 and expected content from the D&D index, `boot.js`, and `payload-01.js`.
- Publish `deploy/pages-production` only after the live smoke test passes; publish failure if the Pages build, deploy, or smoke test fails.

This PR does not change application content. It adds explicit operational evidence and a hard production gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment verification to confirm published pages are responding correctly and displaying expected content.
  * Added clearer build and deployment status reporting, making failed checks easier to identify.
* **Chores**
  * Enhanced continuous integration and publishing workflows with more reliable completion checks and automatic retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->