### PR TITLE
Fix Table Ledger Pages smoke-test title assertion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
             exit 1
           fi
           while IFS= read -r file; do test -s "$root/$file"; done <<< "$expected"
+          grep -Fq '<title>Table Ledger — D&amp;D Character Console</title>' "$root/index.html"
           grep -Fq '4.0.0-srd521' "$root/data.js"
           grep -Fq '4.0.1-ci-remediation' "$root/index.html"
           grep -Fq 'Lisa Blesslie' "$root/data.js"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -61,7 +61,7 @@ jobs:
               [[ "$code" == 200 ]] || ready=0
             done
             if [[ "$ready" == 1 ]] \
-              && grep -Fq '<title>Table Ledger — D&D Character Console</title>' "$work/index.html" \
+              && grep -Fq '<title>Table Ledger — D&amp;D Character Console</title>' "$work/index.html" \
               && grep -Fq 'styles.css' "$work/index.html" \
               && grep -Fq 'data.js' "$work/index.html" \
               && grep -Fq 'app.js' "$work/index.html" \


### PR DESCRIPTION
## Problem

The first post-merge Pages deployment published the direct Table Ledger assets, but the production smoke step compared the raw HTML against an entity-decoded title. The source correctly contains `D&amp;D`; the smoke check incorrectly expected literal `D&D`, so `deploy/pages-production` reported failure.

## Fix

- Match the raw HTML title as `<title>Table Ledger — D&amp;D Character Console</title>`.
- Assert the same exact raw title during PR build CI so this production assertion cannot drift again.

No application behavior or asset content changes.