### PR TITLE
List AtlasSkin 3D on the app catalog

### DIFF
--- a/site/src/data/apps.json
+++ b/site/src/data/apps.json
@@ -28,6 +28,24 @@
     "preview": "https://skinoculars.ramiefathy.com/"
   },
   {
+    "name": "AtlasSkin 3D — DEJ Explorer",
+    "slug": "atlas-skin-3d",
+    "description": "Exploratory interactive teaching model of the dermal–epidermal junction across tissue, ultrastructural, molecular, and cell scales; not biologically validated or intended for clinical use.",
+    "featured": true,
+    "status": "active",
+    "stack": [
+      "React",
+      "Three.js",
+      "Semantic 3D"
+    ],
+    "href": "https://atlas.ramiefathy.com/",
+    "preview": "https://atlas.ramiefathy.com/",
+    "accent": [
+      "#0ea5e9",
+      "#7c3aed"
+    ]
+  },
+  {
     "name": "Dermatopathology Navigator",
     "slug": "dermatopathology-navigator",
     "description": "Modern React-powered learning platform with AI study assistant, spaced repetition, multiple view modes, and comprehensive differential diagnosis builder.",

--- a/site/src/pages/apps/index.astro
+++ b/site/src/pages/apps/index.astro
@@ -7,6 +7,7 @@ import apps from '../../data/apps.json';
 const CATEGORY_BY_SLUG: Record<string, 'clinical' | 'learning' | 'reference' | 'productivity' | 'external'> = {
   'dermatology-scribe': 'clinical',
   'skinoculars': 'clinical',
+  'atlas-skin-3d': 'learning',
   'dermatopathology-navigator': 'learning',
   'mindmaps': 'learning',
   'margin-war-reference-v2': 'learning',

--- a/site/tests/atlas-skin-3d.spec.ts
+++ b/site/tests/atlas-skin-3d.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('AtlasSkin 3D', () => {
+  test('apps catalog exposes the canonical educational explorer subdomain', async ({ page }) => {
+    await page.goto('/apps');
+
+    const appCard = page.locator('.app-plate', { hasText: 'AtlasSkin 3D' });
+    await expect(appCard).toHaveCount(1);
+    await expect(appCard).toHaveAttribute('href', 'https://atlas.ramiefathy.com/');
+    await expect(appCard).toHaveAttribute('target', '_blank');
+    await expect(appCard).toContainText('Exploratory');
+  });
+});


### PR DESCRIPTION
## What changed

Adds the AtlasSkin 3D DEJ Explorer to the public applications catalog at `https://atlas.ramiefathy.com/`, classifies it as a featured learning app, and states its exploratory/non-clinical-use boundary in the card copy.

## Validation

- red-first catalog browser test observed 0 matching cards before implementation
- focused Playwright catalog test passed after implementation
- 217/217 site unit and policy tests passed from a clean source tree
- Astro production build passed (27 pages)

The custom domain will only be attached after the exact merged AtlasSkin source is deployed and passes live acceptance.