### PR TITLE
Improve Rheum-Derm evidence labels and dosing details

### DIFF
--- a/site/public/apps/rheum-derm-clinical-trials/evidence-details-manifest.json
+++ b/site/public/apps/rheum-derm-clinical-trials/evidence-details-manifest.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": 1,
+  "revisionDate": "2026-08-12",
+  "scope": "Rheum-Derm Clinical Trials Evidence Dashboard listing identity and regimen detail enhancement",
+  "sourceArtifact": {
+    "studyCount": 214,
+    "rowsWithNctIdentifiers": 109,
+    "uniqueNctIdentifiers": 143,
+    "htmlBytes": 864417,
+    "htmlSha256": "7da4751bb81838b1dfd7be71a4209d0b90fbcea0c0235b07d6e1da2f4f4e86dc"
+  },
+  "registryReconciliation": {
+    "originalIdentifiersResolved": 143,
+    "originalIdentifiersRequested": 143,
+    "finalSnapshotRecords": 142,
+    "retrievedAt": "2026-08-12",
+    "snapshotBytes": 287865,
+    "snapshotSha256": "0744c5d276c2122e0e4a28de39425e7878747ef57d8025c814b00f83f93df8fb"
+  },
+  "releaseDenominator": {
+    "studyCount": 214,
+    "identifiableUniqueDisplayTitles": 214,
+    "regimenDetailCounts": {
+      "record-dose": 72,
+      "registry-dose": 31,
+      "publication-dose": 2,
+      "variable-regimen": 18,
+      "registry-schedule": 1,
+      "dose-not-reported": 89,
+      "source-mismatch": 1
+    },
+    "sourceMismatchQuarantined": 1
+  },
+  "identityDispositions": [
+    {
+      "studyId": "s082-resolve-1",
+      "disposition": "corrected",
+      "detail": "Renamed to DETERMINE and corrected from NCT03398837 to NCT03813160."
+    },
+    {
+      "studyId": "s085-phase-2-randomized-trial",
+      "disposition": "quarantined",
+      "detail": "Removed rejected NCT04027101 and suppressed efficacy interpretation because the cited registry is BACHELOR in polymyalgia rheumatica, not a brepocitinib dermatomyositis trial."
+    },
+    {
+      "studyId": "s116-rapids-2",
+      "disposition": "corrected",
+      "detail": "Removed unrelated lymphoma registry NCT00301795; retained the RAPIDS-2 primary publication and publication-backed regimen."
+    },
+    {
+      "studyId": "s148-blister",
+      "disposition": "corrected",
+      "detail": "Corrected from unrelated NCT02226146 to ISRCTN13704604."
+    }
+  ],
+  "enhancedArtifact": {
+    "htmlBytes": 1237210,
+    "htmlSha256": "5648daf1a29433105d1a4ec7b83b1bcdf3fdab201b05dbf49ee36d37e076d5a7"
+  },
+  "releaseBoundaries": {
+    "engineeringVerification": "Passed: 5 Node contract tests, 4 focused Chromium tests, 217 repository Vitest tests, exact artifact hash checks, and a production Astro build on 2026-08-12.",
+    "clinicalFacultyReview": "Not performed; required before treating the normalized regimen text as clinically approved content.",
+    "deployment": "Not deployed by this revision."
+  }
+}

--- a/site/public/apps/rheum-derm-clinical-trials/registry-regimens.json
+++ b/site/public/apps/rheum-derm-clinical-trials/registry-regimens.json
@@ -1,0 +1,6020 @@
+{
+  "schemaVersion": 1,
+  "retrievedAt": "2026-08-12",
+  "source": "https://clinicaltrials.gov/api/v2/studies/{NCT_ID}",
+  "recordCount": 142,
+  "records": {
+    "NCT00004563": {
+      "identifier": "NCT00004563",
+      "briefTitle": "Scleroderma Lung Disease",
+      "officialTitle": "Cyclophosphamide Versus Placebo in Scleroderma Lung Study",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2015-03-27",
+      "conditions": [
+        "Lung Diseases",
+        "Pulmonary Fibrosis",
+        "Systemic Scleroderma",
+        "Scleroderma, Systemic"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Cyclophosphamide",
+          "description": "Cyclophosphamide (Cytoxan, Bristol-Myers Squibb) was initiated with a dose of 1 mg per kilogram of body weight per day (to the nearest 25 mg). The doses were increased monthly by one capsule up to 2 mg per kilogram."
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Matching gelcaps 25 mgs"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Cylophosphamide",
+          "type": "EXPERIMENTAL",
+          "description": "Cyclophosphamide (Cytoxan, Bristol-Myers Squibb) was initiated with a dose of 1 mg per kilogram of body weight per day (to the nearest 25 mg). The doses were increased monthly by one capsule up to 2 mg per kilogram."
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Matching gel caps at a dose of 25 mg"
+        }
+      ]
+    },
+    "NCT00051623": {
+      "identifier": "NCT00051623",
+      "briefTitle": "A Study of the Safety and Effectiveness of Infliximab for the Treatment of Psoriatic Arthritis",
+      "officialTitle": "A Multicenter, Randomized, Double-blind Trial of Anti-TNFa Chimeric Monoclonal Antibody (Infliximab) for the Treatment of Patients With Psoriatic Arthritis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2011-05-17",
+      "conditions": [
+        "Arthritis, Psoriatic"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Infliximab",
+          "description": ""
+        }
+      ],
+      "arms": []
+    },
+    "NCT00104299": {
+      "identifier": "NCT00104299",
+      "briefTitle": "Rituximab for the Treatment of Wegener's Granulomatosis and Microscopic Polyangiitis",
+      "officialTitle": "Rituximab Therapy for the Induction of Remission and Tolerance in ANCA-Associated Vasculitis (ITN021AI)",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2017-04-21",
+      "conditions": [
+        "Vasculitis",
+        "Wegener's Granulomatosis",
+        "Microscopic Polyangiitis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Rituximab plus cyclophosphamide placebo (rituximab group)",
+          "description": "375 mg/m\\^2 infusions once weekly for 4 week"
+        },
+        {
+          "type": "DRUG",
+          "name": "Cyclophosphamide plus rituximab placebo (control group)",
+          "description": "2 mg/kg/day orally for months 1-3"
+        },
+        {
+          "type": "DRUG",
+          "name": "Azathioprine",
+          "description": "2 mg/kg/day orally for months 4-6"
+        },
+        {
+          "type": "DRUG",
+          "name": "Methylprednisolone (or other glucocorticoid)",
+          "description": "1 g/day intravenously for up to 3 days within 14 days prior to receiving rituximab"
+        },
+        {
+          "type": "DRUG",
+          "name": "Prednisone",
+          "description": "During the remission induction phase, all participants will receive oral prednisone daily (1 mg/kg/day, not to exceed 80 mg/day). Prednisone tapering will be completed by the Month 6 study visit."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Rituximab",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        },
+        {
+          "label": "Control Group",
+          "type": "ACTIVE_COMPARATOR",
+          "description": ""
+        }
+      ]
+    },
+    "NCT00106184": {
+      "identifier": "NCT00106184",
+      "briefTitle": "Rituximab for the Treatment of Refractory Adult and Juvenile Dermatomyositis (DM) and Adult Polymyositis (PM)",
+      "officialTitle": "Rituximab Therapy in Refractory Adult and Juvenile Idiopathic Inflammatory Myopathy (IIM)",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2015-03-04",
+      "conditions": [
+        "Myositis",
+        "Dermatomyositis",
+        "Polymyositis",
+        "Juvenile Dermatomyositis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Rituximab",
+          "description": "Treatment Group A - intravenous rituximab 750mg/m2 BSA (Body Surface Area) up to a maximum dose of 1 gram at Weeks 0 and 1 Group B - intravenous rituximab 750mg/m2 BSA (Body Surface Area) up to a maximum does of 1 gram at Weeks 8 and 9"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Treatment Group A: placebo infusion at Weeks 8 and 9 Treatment Group B: placebo infusion at Weeks 0 and 1"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Adult Study Group 1",
+          "type": "EXPERIMENTAL",
+          "description": "Refractory adult polymyositis patients who will receive rituximab at Weeks 0 and 1 followed by placebo at Weeks 8 and 9 (Treatment Group A)"
+        },
+        {
+          "label": "Adult Study Group 2",
+          "type": "EXPERIMENTAL",
+          "description": "Refractory adult polymyositis patients who will receive placebo at Weeks 0 and 1 followed by rituximab at Weeks 8 and 9 (Treatment Group B)"
+        },
+        {
+          "label": "Adult Study Group 3",
+          "type": "EXPERIMENTAL",
+          "description": "Adult dermatomyositis patients who will receive rituximab at Weeks 0 and 1 followed by placebo at Weeks 8 and 9 (Treatment Group A)"
+        },
+        {
+          "label": "Adult Study Group 4",
+          "type": "EXPERIMENTAL",
+          "description": "Adult dermatomyositis patients who will receive placebo at Weeks 0 and 1 followed by rituximab at Weeks 8 and 9 (Treatment Group B)"
+        },
+        {
+          "label": "JDM Study Group 1",
+          "type": "EXPERIMENTAL",
+          "description": "Refractory juvenile dermatomyositis patients who will receive rituximab at Weeks 0 and 1 followed by placebo at Weeks 8 and 9 (Treatment Group A)"
+        },
+        {
+          "label": "JDM Study Group 2",
+          "type": "EXPERIMENTAL",
+          "description": "Refractory juvenile dermatomyositis patients who will receive placebo at Weeks 0 and 1 followed by rituximab at Weeks 8 and 9 (Treatment Group B)"
+        }
+      ]
+    },
+    "NCT00106834": {
+      "identifier": "NCT00106834",
+      "briefTitle": "A Study of the Safety and Efficacy of Infliximab in Patients With Psoriasis",
+      "officialTitle": "A Phase 3, Multi-Center, Randomized, Double-Blind, Placebo-Controlled Trial Evaluating the Efficacy and Safety of Infliximab Induction and Maintenance Therapy in Patients With Moderate to Severe Plaque Psoriasis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2011-05-19",
+      "conditions": [
+        "Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Infliximab",
+          "description": ""
+        }
+      ],
+      "arms": []
+    },
+    "NCT00114530": {
+      "identifier": "NCT00114530",
+      "briefTitle": "Scleroderma: Cyclophosphamide or Transplantation",
+      "officialTitle": "A Randomized, Open-Label, Phase II Multicenter Study of High-Dose Immunosuppressive Therapy Using Total Body Irradiation, Cyclophosphamide, ATGAM, and Autologous Transplantation With Auto-CD34+HPC Versus Intravenous Pulse Cyclophosphamide for the Treatment of Severe Systemic Sclerosis (SCSSc-01)",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2023-04-12",
+      "conditions": [
+        "Scleroderma, Systemic",
+        "Sclerosis",
+        "Autoimmune Disease"
+      ],
+      "interventions": [
+        {
+          "type": "BIOLOGICAL",
+          "name": "mHSCT",
+          "description": "Hematopoietic progenitors were mobilized with G-CSF. After leukapheresis and CD34+ cell enrichment, the autologous product was cryopreserved. Fractionated TBI (800 cGy), CY (120 mg/kg) and equine antithymocyte globulin (90 mg/kg) were administered as previously reported (References provided in citation section of this ClinicalTrials.gov record: PubMed ID: 17452515 citation and 2.) PubMed ID: 12176878 citation)."
+        },
+        {
+          "type": "DRUG",
+          "name": "cyclophosphamide",
+          "description": "An initial intravenous dose of 500 mg/m\\^2 was followed by 11 infusions of 750 mg/m\\^2 with mesna given for bladder protection."
+        }
+      ],
+      "arms": [
+        {
+          "label": "mHSCT",
+          "type": "EXPERIMENTAL",
+          "description": "Myeloablative Hematopoietic Stem Cell Transplant (mHSCT) Participants will first have hematopoietic stem cells removed from their blood. They then will receive high doses of chemotherapy and radiation to eliminate their developed and presumably abnormal immune system, followed by autologous stem cell transplantation to reintroduce the purified stem cells to re-establish their immune system."
+        },
+        {
+          "label": "cyclophosphamide",
+          "type": "EXPERIMENTAL",
+          "description": "Cyclophosphamide (CY) Participants will receive high doses of intravenous cyclophosphamide. The dose being used in this study is about 50% higher than that commonly used by most physicians to treat many other autoimmune diseases. Administration of 12 monthly pulses of high-dose intravenous cyclophosphamide (an initial dose of 500 mg/m\\^2, followed by 11 doses of 750 mg/m\\^2)."
+        }
+      ]
+    },
+    "NCT00137969": {
+      "identifier": "NCT00137969",
+      "briefTitle": "A Study to Evaluate the Safety of Rituximab Retreatment in Subjects With Systemic Lupus Erythematosus",
+      "officialTitle": "Randomized, Double-blind, Placebo-controlled, Multicenter, Phase II/III Study to Evaluate the Efficacy and Safety of Rituximab in Subjects With Moderate to Severe Systemic Lupus Erythematosus",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2019-08-20",
+      "conditions": [
+        "Lupus Erythematosus, Systemic"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Rituximab",
+          "description": "Rituximab will be supplied as a sterile liquid for IV administration."
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Placebo will be supplied as a sterile liquid for IV administration."
+        },
+        {
+          "type": "DRUG",
+          "name": "Prednisone",
+          "description": ""
+        },
+        {
+          "type": "DRUG",
+          "name": "Acetaminophen",
+          "description": ""
+        },
+        {
+          "type": "DRUG",
+          "name": "Diphenhydramine",
+          "description": ""
+        }
+      ],
+      "arms": [
+        {
+          "label": "Rituximab 1000 mg + prednisone",
+          "type": "EXPERIMENTAL",
+          "description": "Participants will receive rituximab 1000 mg intravenously on Days 1, 15, 168, and 182. Participants will also receive an initial dose of prednisone (0.5, 0.75, or 1.0 mg/kg orally once a day) with tapering beginning at Day 16 for 10 weeks to a dose of ≤ 10 mg/day. Participants will also receive acetaminophen 1000 mg orally and diphenhydramine 50 mg orally prior to study drug infusion."
+        },
+        {
+          "label": "Placebo + prednisone",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants will receive placebo intravenously on Days 1, 15, 168, and 182. Participants will also receive an initial dose of prednisone (0.5, 0.75, or 1.0 mg/kg orally once a day) with tapering beginning at Day 16 for 10 weeks to a dose of ≤ 10 mg/day. Participants will also receive acetaminophen 1000 mg orally and diphenhydramine 50 mg orally prior to study drug infusion."
+        }
+      ]
+    },
+    "NCT00235820": {
+      "identifier": "NCT00235820",
+      "briefTitle": "Safety and Efficacy of Adalimumab to Methotrexate and Placebo in Subjects With Moderate to Severe Chronic Plaque Psoriasis",
+      "officialTitle": "A Phase 3, Multicenter, Randomized, Double-Blind, Double-Dummy, Placebo-Controlled Study Comparing the Safety and Efficacy of Adalimumab to Methotrexate in Subjects With Moderate to Severe Chronic Plaque Psoriasis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2008-07-17",
+      "conditions": [
+        "Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "adalimumab",
+          "description": "40 mg every other week following an 80 mg dose"
+        },
+        {
+          "type": "DRUG",
+          "name": "MTX",
+          "description": "MTX 7.5 to 25 mg once weekly"
+        },
+        {
+          "type": "DRUG",
+          "name": "placebo adalimumab, placebo MTX",
+          "description": "placebo injections once every other week after 2 injections at Baseline (adalimumab) placebo capsules once weekly (MTX)"
+        }
+      ],
+      "arms": [
+        {
+          "label": "A",
+          "type": "ACTIVE_COMPARATOR",
+          "description": ""
+        },
+        {
+          "label": "B",
+          "type": "ACTIVE_COMPARATOR",
+          "description": ""
+        },
+        {
+          "label": "C",
+          "type": "PLACEBO_COMPARATOR",
+          "description": ""
+        }
+      ]
+    },
+    "NCT00237887": {
+      "identifier": "NCT00237887",
+      "briefTitle": "Efficacy and Safety of Adalimumab in Subjects With Moderate to Severe Chronic Plaque Psoriasis",
+      "officialTitle": "A Phase III, Multicenter Study of the Efficacy and Safety of Adalimumab Treatment in Subjects With Moderate to Severe Chronic Plaque Psoriasis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2007-08-29",
+      "conditions": [
+        "Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "adalimumab",
+          "description": ""
+        }
+      ],
+      "arms": []
+    },
+    "NCT00265096": {
+      "identifier": "NCT00265096",
+      "briefTitle": "A Study of the Safety and Efficacy of Golimumab in Patients With Active Psoriatic Arthritis",
+      "officialTitle": "A Multicenter, Randomized, Double-blind, Placebo-controlled Trial of Golimumab, a Fully Human Anti-TNFa MonoclonalAntibody, Administered Subcutaneously in Subjects With Active Psoriatic Arthritis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2013-07-19",
+      "conditions": [
+        "Arthritis, Psoriatic"
+      ],
+      "interventions": [
+        {
+          "type": "BIOLOGICAL",
+          "name": "golimumab",
+          "description": "50 mg sc injs every 4 wks from wk 0 thru 5 yrs (unless early escape at wk 16); golimumab - if early escape, 100mg sc injection every 4 wks beginning wk 16 up to 5 yrs; golimumab - Dr's discretion after unblinding, dose adjust from 50 to 100mg"
+        },
+        {
+          "type": "BIOLOGICAL",
+          "name": "Placebo; golimumab",
+          "description": "SC injections ever 4 wks thru Wk 20 (unless early escape at wk 16); golimumab - if early escape, 50mg sc injection from wk 16 up to 5 yrs; golimumab -50mg sc injection beginning Wk 24 up to 5 yrs (unless early escape); golimumab - Dr's discretion after unblinding, dose adjust from 50 to 100 mg"
+        },
+        {
+          "type": "BIOLOGICAL",
+          "name": "golimumab",
+          "description": "100 mg sc injections every 4 wks from wk 0 up to 5 yrs"
+        }
+      ],
+      "arms": [
+        {
+          "label": "002",
+          "type": "EXPERIMENTAL",
+          "description": "golimumab 50 mg sc injs every 4 wks from wk 0 thru 5 yrs (unless early escape at wk 16); golimumab - if early escape, 100mg sc injection every 4 wks beginning wk 16 up to 5 yrs; golimumab - Dr's discretion after unblinding, dose adjust from 50 to 100mg"
+        },
+        {
+          "label": "001",
+          "type": "EXPERIMENTAL",
+          "description": "Placebo; golimumab SC injections ever 4 wks thru Wk 20 (unless early escape at wk 16); golimumab - if early escape, 50mg sc injection from wk 16 up to 5 yrs; golimumab -50mg sc injection beginning Wk 24 up to 5 yrs (unless early escape); golimumab - Dr's discretion after unblinding, dose adjust from 50 to 100 mg"
+        },
+        {
+          "label": "003",
+          "type": "EXPERIMENTAL",
+          "description": "golimumab 100 mg sc injections every 4 wks from wk 0 up to 5 yrs"
+        }
+      ]
+    },
+    "NCT00267969": {
+      "identifier": "NCT00267969",
+      "briefTitle": "A Study of Safety and Effectiveness of Ustekinumab (CNTO 1275) in Patients With Moderate to Severe Plaque-type Psoriasis",
+      "officialTitle": "A Phase 3, Multicenter, Randomized, Double-blind, Placebo Controlled Trial Evaluating the Efficacy and Safety of Ustekinumab (CNTO 1275) in the Treatment of Subjects With Moderate to Severe Plaque-type Psoriasis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2013-06-17",
+      "conditions": [
+        "Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "ustekinumab",
+          "description": "Type = exact number, Form = solution for injection, Number = 45 and 90, Unit = mg, Route = subcutaneous (SC) administered at Weeks 0, 4 and 16. Both treatments (45 mg and 90 mg) administered every 12 weeks after Week 16 depending on clinical response."
+        },
+        {
+          "type": "DRUG",
+          "name": "placebo",
+          "description": "Form = solution for injection, route = SC administered at Weeks 0 and 4. At Weeks 12 and 16, placebo will be crossed over to receive ustekinumab 45 mg or 90 mg."
+        }
+      ],
+      "arms": [
+        {
+          "label": "ustekinumab 45 mg",
+          "type": "EXPERIMENTAL",
+          "description": "Patients received ustekinumab 45 mg at Weeks 0, 4 and 16. Treatments after Week 16 were dependent on clinical response. At Week 40, patients who achieved PASI 75 at both Week 28 and Week 40 were re-randomized to withdraw from therapy (placebo) or continue 45 mg every 12 week maintenance therapy."
+        },
+        {
+          "label": "ustekinumab 90 mg",
+          "type": "EXPERIMENTAL",
+          "description": "Patients received ustekinumab 90 mg at Week 0, 4 and 16. Treatments after Week 16 were dependent on clinical response. At Week 40, patients who achieved PASI 75 at both Week 28 and Week 40 were re-randomized to withdraw from therapy (placebo) or continue 90 mg every 12 week maintenance therapy."
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Patients received placebo at Weeks 0 and 4. At Weeks 12 and 16, placebo crossed over to receive ustekinumab 45 mg or 90 mg. Treatments after Week 16 were dependent on clinical response."
+        }
+      ]
+    },
+    "NCT00278525": {
+      "identifier": "NCT00278525",
+      "briefTitle": "Cyclophosphamide and rATG With Hematopoietic Stem Cell Support in Systemic Scleroderma",
+      "officialTitle": "Trial of High Dose Cyclophosphamide and Rabbit Antithymocyte Globulin (rATG) With Hematopoietic Stem Cell Support in Patients With Systemic Scleroderma: A Randomized Trial",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2014-04-30",
+      "conditions": [
+        "SYSTEMIC SCLERODERMA"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "standard of care",
+          "description": "standard of care medication will be given"
+        },
+        {
+          "type": "PROCEDURE",
+          "name": "stem cell transplantation",
+          "description": "The following is intervention: stem cell transplantation after conditioning regimen"
+        }
+      ],
+      "arms": [
+        {
+          "label": "stem cell trasplantation",
+          "type": "EXPERIMENTAL",
+          "description": "intervention as stem cell transplantation after conditioning regimen"
+        },
+        {
+          "label": "standard of care",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "medication as standard of care will be given"
+        }
+      ]
+    },
+    "NCT00307437": {
+      "identifier": "NCT00307437",
+      "briefTitle": "A Study of the Safety and Efficacy of Ustekinumab (CNTO 1275) in Patients With Moderate to Severe Psoriasis",
+      "officialTitle": "A Phase 3, Multicenter, Randomized, Double-blind, Placebo-controlled Trial Evaluating the Efficacy and Safety of CNTO 1275 in the Treatment of Subjects With Moderate to Severe Plaque-type Psoriasis.",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2013-01-24",
+      "conditions": [
+        "Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Placebo; Ustekinumab (CNTO 1275) 45 or 90 mg",
+          "description": "Placebo at Weeks 0 and 4 and blinded SC injections of ustekinumab, 45 or 90 mg, at Weeks 12 and 16; followed by a dosing regimen to be determined by patient's response status for Weeks 28 to 52; followed by unblinded dosing that may be adjusted at the investigator's discretion for Weeks 52 to 264"
+        },
+        {
+          "type": "DRUG",
+          "name": "Ustekinumab (CNTO 1275) 45 mg",
+          "description": "Ustekinumab, 45 mg, at Weeks 0 and 4 and every 12 weeks for Weeks 16 to 28. Followed by a dosing regimen to be determined by patient's response status for Weeks 28 to 52; followed by unblinded dosing that may be adjusted at the investigator's discretion for Weeks 52 to 264"
+        },
+        {
+          "type": "DRUG",
+          "name": "Ustekinumab (CNTO 1275) 90 mg",
+          "description": "Ustekinumab, 90 mg, at Weeks 0 and 4 and every 12 weeks for Weeks 16 to 28. Followed by a dosing regimen to be determined by patient's response status for Weeks 28 to 52; followed by unblinded dosing that may be adjusted at the investigator's discretion for Weeks 52 to 264"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Group I: Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": ""
+        },
+        {
+          "label": "Group II: Ustekinumab 45 mg",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        },
+        {
+          "label": "Group III: Ustekinumab 90 mg",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        }
+      ]
+    },
+    "NCT00410384": {
+      "identifier": "NCT00410384",
+      "briefTitle": "A Study of Belimumab in Subjects With Systemic Lupus Erythematosus",
+      "officialTitle": "A Phase 3, Multi-Center, Randomized, Double-Blind, Placebo-Controlled, 76-Week Study to Evaluate the Efficacy and Safety of Belimumab (HGS1006, LymphoStat-B™), a Fully Human Monoclonal Anti-BLyS Antibody, in Subjects With Systemic Lupus Erythematosus (SLE)",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2017-02-01",
+      "conditions": [
+        "Systemic Lupus Erythematosus"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Placebo IV plus standard therapy; placebo administered on Days 0, 14, 28, and every 28 days thereafter through 72 weeks."
+        },
+        {
+          "type": "DRUG",
+          "name": "Belimumab 1 mg/kg",
+          "description": "Belimumab 1 mg/kg IV plus standard therapy; belimumab 1 mg/kg administered on Days 0, 14, 28, and every 28 days thereafter through 72 weeks."
+        },
+        {
+          "type": "DRUG",
+          "name": "Belimumab 10 mg/kg",
+          "description": "Belimumab 10 mg/kg IV plus standard therapy; belimumab 10 mg/kg administered on Days 0, 14, 28, and every 28 days thereafter through 72 weeks."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo"
+        },
+        {
+          "label": "Belimumab 1 mg/kg",
+          "type": "EXPERIMENTAL",
+          "description": "Belimumab 1 mg/kg"
+        },
+        {
+          "label": "Belimumab 10 mg/kg",
+          "type": "EXPERIMENTAL",
+          "description": "Belimumab 10 mg/kg"
+        }
+      ]
+    },
+    "NCT00424476": {
+      "identifier": "NCT00424476",
+      "briefTitle": "A Study of Belimumab in Subjects With Systemic Lupus Erythematosus (SLE)",
+      "officialTitle": "A Phase 3, Multi-Center, Randomized, Double-Blind, Placebo-Controlled, 52-Wk Study to Evaluate the Efficacy and Safety of Belimumab (HGS1006, LymphoStat-B™), a Fully Human Monoclonal Anti-BLyS Antibody, in Subjects With Systemic Lupus Erythematosus (SLE)",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2016-12-12",
+      "conditions": [
+        "Systemic Lupus Erythematosus"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Placebo IV plus standard therapy; placebo administered on Days 0, 14, 28, and every 28 days thereafter through Week 48."
+        },
+        {
+          "type": "DRUG",
+          "name": "Belimumab 1 mg/kg",
+          "description": "Belimumab 1 mg/kg IV plus standard therapy on Days 0, 14, 28, and every 28 days thereafter through Week 48."
+        },
+        {
+          "type": "DRUG",
+          "name": "Belimumab 10 mg/kg",
+          "description": "Belimumab 10 mg/kg IV plus standard therapy on Days 0, 14, 28, and every 28 days thereafter through Week 48."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo"
+        },
+        {
+          "label": "Belimumab 1 mg/kg",
+          "type": "EXPERIMENTAL",
+          "description": "Belimumab 1 mg/kg"
+        },
+        {
+          "label": "Belimumab 10 mg/kg",
+          "type": "EXPERIMENTAL",
+          "description": "Belimumab 10 mg/kg"
+        }
+      ]
+    },
+    "NCT00454584": {
+      "identifier": "NCT00454584",
+      "briefTitle": "An Efficacy and Safety Study of CNTO 1275 Compared to Etanercept in Patients With Plaque Psoriasis",
+      "officialTitle": "A Phase 3, Multicenter, Randomized Study Comparing CNTO 1275 and Etanercept for the Treatment of Moderate to Severe Plaque Psoriasis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2012-11-21",
+      "conditions": [
+        "Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "CNTO 1275 45 mg",
+          "description": "Type=exact number, number=45, unit=mg, form=injection, route=subcutaneous"
+        },
+        {
+          "type": "DRUG",
+          "name": "CNTO 1275 90 mg",
+          "description": "Type=exact number, number=90, unit=mg, form=injection, route=subcutaneous"
+        },
+        {
+          "type": "DRUG",
+          "name": "Etanercept 50 mg",
+          "description": "Type=exact number, number=50, unit=mg, form=injection, route=subcutaneous"
+        }
+      ],
+      "arms": [
+        {
+          "label": "CNTO 1275 45 mg",
+          "type": "EXPERIMENTAL",
+          "description": "Patients will receive CNTO 1275 45 mg at the Weeks 0 and 4 visits. Treatment after Week 12 is dependent on Physician's Global Assessment (PGA) response at Week 12 and initial treatment assignment."
+        },
+        {
+          "label": "CNTO 1275 90 mg",
+          "type": "EXPERIMENTAL",
+          "description": "Patients will receive CNTO 1275 90 mg at the Weeks 0 and 4 visits. Treatment after Week 12 is dependent on PGA response at Week 12 and initial treatment assignment."
+        },
+        {
+          "label": "Etanercept 50 mg",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Patients will receive Etanercept 50 mg twice weekly through Week 12. Treatment after Week 12 is dependent on PGA response at Week 12 and initial treatment assignment."
+        }
+      ]
+    },
+    "NCT00646386": {
+      "identifier": "NCT00646386",
+      "briefTitle": "Study of the Safety and Efficacy of the Human Anti-TNF Monoclonal Antibody Adalimumab in Subjects With Moderately to Severely Active Psoriatic Arthritis",
+      "officialTitle": "Multicenter Study of the Safety and Efficacy of the Human Anti-TNF Monoclonal Antibody Adalimumab in Subjects With Moderately to Severely Active Psoriatic Arthritis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2008-03-28",
+      "conditions": [
+        "Arthritis",
+        "Psoriatic"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "adalimumab",
+          "description": "40 mg eow Week 0 - Week 24"
+        },
+        {
+          "type": "DRUG",
+          "name": "placebo for adalimumab",
+          "description": "40 mg eow Week 0 - Week 24"
+        }
+      ],
+      "arms": [
+        {
+          "label": "A",
+          "type": "ACTIVE_COMPARATOR",
+          "description": ""
+        },
+        {
+          "label": "B",
+          "type": "PLACEBO_COMPARATOR",
+          "description": ""
+        }
+      ]
+    },
+    "NCT00784589": {
+      "identifier": "NCT00784589",
+      "briefTitle": "Comparison Between Rituximab Treatment and General Corticotherapy Treatment in Patients With Pemphigus",
+      "officialTitle": "Comparison Between Monoclonal Antibody CD20 Treatment (Rituximab (mabthéra))and General Corticotherapy Treatment in Patients With Pemphigus",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2017-06-14",
+      "conditions": [
+        "Pemphigus Disease"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "General Corticotherapy",
+          "description": "for patients with severe pemphigus : general corticotherapy Arm : 1.5mg/kg/d for 1 month, then 1.25mg/kg/d for 1 month, then 1mg/kg/d for 1 month, then 0.75 mg/kg/d for 1 month, then 0.5 mg/kg/d for 3 months, then 0.3 mg/kg/d for 3 months, then 0.2 mg/kg/d for 4 months, then 0.1 mg/kg/d for 4 months, for patients with moderated pemphigus : general corticotherapy Arm : 1mg/kg/d for 1 month, then 0.75mg/kg/d for 1 month, then 0.5mg/kg/d for 2 months, then 0.3 mg/kg/d for 2 months, then 0.2 mg/kg/d for 3 months, then 0.1 mg/kg/d for 3 months,"
+        },
+        {
+          "type": "DRUG",
+          "name": "Rituximab",
+          "description": "for patients with severe pemphigus : rituximab Arm : 1mg/kg/d for 1 month, then 0.75 mg/kg/d for 1 month, then 0.5 mg/kg/d for 1 month, then 0.3 mg/kg/d for 1 month, then 0.2 mg/kg/d for 1 month, then 0.1 mg/kg/d for 1 month for patients with moderated pemphigus : rituximab Arm : 0.5mg/kg/d for 1 month, then 0.30 mg/kg/d for 1 month, then 0.2 mg/kg/d for 1 month,"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Rituximab",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        },
+        {
+          "label": "Corticotherapy",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "General Corticotherapy"
+        }
+      ]
+    },
+    "NCT00866359": {
+      "identifier": "NCT00866359",
+      "briefTitle": "A Study to Evaluate the Efficacy and Safety of Apremilast (CC-10004) in the Treatment of Behçet Disease",
+      "officialTitle": "A Phase 2, Multi-center, Randomized, Double-blind, Placebo-controlled, Parallel-group Study Followed by an Active-Treatment Extension to Evaluate the Efficacy and Safety of Apremilast(CC-10004) in the Treatment of Behçet Disease",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2020-06-19",
+      "conditions": [
+        "Behcet Syndrome"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Apremilast (CC-10004)",
+          "description": "Treatment Phase Days 1-7: Titration from 10 mg BID apremilast tablets arm A (or matching placebo arm B) to 30 mg BID apremilast arm A(or matching placebo arm B) Day 8-84: Maintenance of 30 mg BID apremilast arm A (or matching placebo arm B) Dose reductions to 20 mg BID apremilast arm A (or matching placebo arm B) are permitted. Extension Phase All subjects will be given active drug Days 85-91: All placebo subjects from Treatment phase will be dose titrated from 10 mg BID apremilast tablets arm A to 30 mg BID Apremilast. Day 92-169: Maintenance of 30 mg BID apremilast arm A or dose reductions to 20 mg BID apremilast arm A (if not previously down titrated)"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Treatment Phase Days 1-7: Titration from 10mg BID matching placebo (arm B) to 30mg BID placebo (arm B) Day 8-84: Maintenance of 30mg BID placebo (arm B). Dose reductions to 20 mg BID matching placebo (arm B) are permitted. Extension Phase All subjects will be given active drug Days 85-91: All placebo subjects from Treatment phase will be dose titrated from 10 mg BID apremilast tablets arm A to 30 mg BID Apremilast. Day 92-169: Maintenance of 30 mg BID apremilast or dose reductions to 20 mg BID apremilast (if not previously down titrated)"
+        }
+      ],
+      "arms": [
+        {
+          "label": "A. Apremilast",
+          "type": "ACTIVE_COMPARATOR",
+          "description": ""
+        },
+        {
+          "label": "B. Placebo Comparator",
+          "type": "PLACEBO_COMPARATOR",
+          "description": ""
+        }
+      ]
+    },
+    "NCT00883129": {
+      "identifier": "NCT00883129",
+      "briefTitle": "Comparison of Therapeutic Regimens for Scleroderma Interstitial Lung Disease (The Scleroderma Lung Study II)",
+      "officialTitle": "Mycophenolate vs. Oral Cyclophosphamide in Scleroderma Interstitial Lung Disease (Scleroderma Lung Study II)",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2017-02-10",
+      "conditions": [
+        "Scleroderma",
+        "Interstitial Lung Disease"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Mycophenolate mofetil",
+          "description": "24 months of oral mycophenolate mofetil, up to a maximal dose of 1.5 grams twice daily as tolerated"
+        },
+        {
+          "type": "DRUG",
+          "name": "Cyclophosphamide",
+          "description": "12 months of oral cyclophosphamide, up to a maximal dose of 2 mg/kg daily as tolerated"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "12 months of placebo will be delivered to participants in the Cyclophosphamide arm during the second year in order to maintain the blind with the Mycophenolate arm, which receives drug for the entire 2 years."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Mycophenolate Arm",
+          "type": "EXPERIMENTAL",
+          "description": "Participants will receive oral mycophenolate mofetil for 2 years."
+        },
+        {
+          "label": "Cyclophosphamide Arm",
+          "type": "EXPERIMENTAL",
+          "description": "Participants will receive oral cyclophosphamide for 1 year, followed by placebo for 1 year."
+        }
+      ]
+    },
+    "NCT00987389": {
+      "identifier": "NCT00987389",
+      "briefTitle": "Plasma Exchange and Glucocorticoids for Treatment of Anti-Neutrophil Cytoplasm Antibody (ANCA) - Associated Vasculitis",
+      "officialTitle": "Plasma Exchange and Glucocorticoid Dosing in the Treatment of Anti-neutrophil Cytoplasm Antibody Associated Vasculitis: an International Randomized Controlled Trial",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2020-05-26",
+      "conditions": [
+        "Granulomatosis With Polyangiitis (Wegener's) (GPA)",
+        "Microscopic Polyangiitis (MPA)"
+      ],
+      "interventions": [
+        {
+          "type": "PROCEDURE",
+          "name": "Plasma Exchange",
+          "description": "Plasma exchange is a procedure whereby blood is taken from the body and separated by a machine into blood cells and plasma, which is the liquid part of blood. The plasma is discarded and the blood cells are returned to the body with a plasma substitute."
+        },
+        {
+          "type": "OTHER",
+          "name": "No Plasma Exchange",
+          "description": "No plasma exchange."
+        },
+        {
+          "type": "DRUG",
+          "name": "Glucocorticoids [Standard Dose]",
+          "description": "During the study, a standard glucocorticoids dose regimen will be compared to a reduced glucocorticoids dose regimen. All subjects' patients will receive the same glucocorticoids dose for the first two weeks then the dose will decrease following a standard regimen."
+        },
+        {
+          "type": "DRUG",
+          "name": "Glucocorticoids [Reduced Dose]",
+          "description": "During the study, a standard glucocorticoids dose regimen will be compared to a reduced glucocorticoids dose regimen. All subjects' patients will receive the same glucocorticoids dose for the first two weeks then the dose will decrease following a reduced regimen."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Plasma Exchange with Standard Glucocorticoids",
+          "type": "EXPERIMENTAL",
+          "description": "Participants in this arm undergo plasma exchange and take a standard glucocorticoid dose."
+        },
+        {
+          "label": "No Plasma Exchange with Standard Glucocorticoids",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Participants in this arm do not undergo plasma exchange and take a standard glucocorticoid dose."
+        },
+        {
+          "label": "Plasma Exchange with Reduced-Dose Glucocorticoids",
+          "type": "EXPERIMENTAL",
+          "description": "Participants in this arm undergo plasma exchange and take a reduced glucocorticoid dose."
+        },
+        {
+          "label": "No Plasma Exchange with Reduced-Dose Glucocorticoids",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Participants in this arm do not undergo plasma exchange and take a reduced glucocorticoid dose."
+        }
+      ]
+    },
+    "NCT01106079": {
+      "identifier": "NCT01106079",
+      "briefTitle": "TIght COntrol of Psoriatic Arthritis",
+      "officialTitle": "A Randomised Controlled Trial to Compare Intensive Management vs Standard Care in Early Psoriatic Arthritis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2015-05-28",
+      "conditions": [
+        "Psoriatic Arthritis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Intensive management or Tight control",
+          "description": "Those subjects randomised to the intensive management or tight control arm will be reviewed every 4 weeks (by the Principal Investigator at each site or a designated researcher) and will be treated according to a rapidly escalating regime, involving standard DMARDs and biologics. Initial therapy will be with oral methotrexate, increasing in dose rapidly over the first 8 weeks of the study. From the 12 week visit onwards, escalation of therapy in this arm will be performed if subjects do not meet the objective target of Minimal Disease Activity. Initial escalation will be to combination DMARD therapy. If patients in the tight control arm fail to meet the MDA criteria and fulfil the NICE criteria for the use of TNF blockers in psoriatic arthritis at 24 weeks, then they will be offered treatment with these medications. Therapy will continue to be modified throughout the 48 week follow-up until a state of minimal disease activity is reached."
+        },
+        {
+          "type": "DRUG",
+          "name": "Standard management - Control group",
+          "description": "The control group will be seen every 12 weeks in a general rheumatology clinic and will receive standard care, involving standard DMARDs and biologics as appropriate. Treatment will be prescribed as felt appropriate by the treating physicians with no set protocol and no restrictions."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Intensive management",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        },
+        {
+          "label": "Standard management",
+          "type": "ACTIVE_COMPARATOR",
+          "description": ""
+        }
+      ]
+    },
+    "NCT01172938": {
+      "identifier": "NCT01172938",
+      "briefTitle": "Efficacy and Safety Study of Apremilast to Treat Active Psoriatic Arthritis",
+      "officialTitle": "A Phase 3, Multicenter, Randomized, Double-blind, Placebo-controlled, Parallel-group, Efficacy and Safety Study of Two Doses of Apremilast (CC-10004) in Subjects With Active Psoriatic Arthritis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2020-06-19",
+      "conditions": [
+        "Psoriatic Arthritis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Apremilast 20mg",
+          "description": "Apremilast 20 mg twice daily, orally"
+        },
+        {
+          "type": "DRUG",
+          "name": "Apremilast 30mg",
+          "description": "Apremilast 30 mg twice daily, orally"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo + 20 mg Apremilast",
+          "description": "Placebo + 20 mg Apremilast"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo + 30 mg Apremilast",
+          "description": "Placebo + 30 mg Apremilast"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Apremilast 20 mg",
+          "type": "EXPERIMENTAL",
+          "description": "20 mg Apremilast tablets administered twice daily for 24 weeks during the placebo-controlled phase followed by 20 mg Apremilast tablets administered twice daily for up to 4.5 years in the active treatment / long-term safety phase"
+        },
+        {
+          "label": "Apremilast 30mg",
+          "type": "EXPERIMENTAL",
+          "description": "30 mg Apremilast tablets administered twice a day for 24 weeks during the placebo-controlled phase followed by 30 mg Apremilast tablets administered twice a day for up to 4.5 years in the active treatment / long-term safety phase orally twice daily"
+        },
+        {
+          "label": "Placebo + 20 mg Apremilast",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo + 20 mg Apremilast tablets administered twice daily for 24 weeks during the placebo-controlled phase followed by 20 mg Apremilast tablets administered twice daily for up to 4.5 years in the active treatment / long-term safety phase. Subjects who do not have at least 20% improvement in their swollen and tender joint counts at Week 16 will escape to 20 mg Apremilast twice daily at Week 16"
+        },
+        {
+          "label": "Placebo + 30 mg Apremilast",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo + 30 mg Apremilast tablets administered twice daily for 24 weeks during the placebo-controlled phase followed by 30 mg Apremilast tablets administered twice daily for up to 4.5 years in the active treatment / long-term safety phase. Subjects who do not have at least 20% improvement in their swollen and tender joint counts at Week 16 will escape to 30 mg Apremilast twice daily at Week 16."
+        }
+      ]
+    },
+    "NCT01194219": {
+      "identifier": "NCT01194219",
+      "briefTitle": "Study to Evaluate Safety and Effectiveness of Oral Apremilast (CC-10004) in Patients With Moderate to Severe Plaque Psoriasis",
+      "officialTitle": "A Phase 3, Multicenter, Randomized, Double-Blind, Placebo-Controlled, Efficacy and Safety Study of Apremilast (CC-10004) in Subjects With Moderate to Severe Plaque Psoriasis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2022-03-15",
+      "conditions": [
+        "Plaque Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Apremilast",
+          "description": ""
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Identical matching placebo"
+        },
+        {
+          "type": "DRUG",
+          "name": "Topical treatments or phototherapy",
+          "description": "At week 32, participants considered partial responders or non-responders had the option of adding topical therapies and/or phototherapy to their treatment regimen."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Apremilast",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Subjects initially randomized to apremilast 30 mg twice a day, and who demonstrate a PASI 75 response at Week 32 will be randomized (1 to 1) to either continue to receive apremilast 30 mg ) BID or to receive placebo (until effect is lost). At the time effect is lost, subjects will be treated with apremilast 30 mg twice a day for the duration of their participation in the study."
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Subjects initially randomized to placebo, are assigned to apremilast 30 mg twice a day beginning at Week 16 for the duration of the subject's participation in the study."
+        },
+        {
+          "label": "Apremilast 30 mg",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Apremilast 30 mg by mouth (PO) twice a day (BID). Participants initially randomized to apremilast 30 mg BID, and who were able to demonstrate a Psoriasis Area Severity Index (PASI) -75 response at week 32 were randomized (1 to 1) to either apremilast 30 mg BID or oral placebo (until effect is lost). At relapse/loss of response to therapy prior to Week 52 (the time at which 75% improvement in PASI score compared to baseline was lost) or at Week 52, participants were re-treated with apremilast 30 mg BID for the duration of their participation in the study. Non-responders or partial responders (PASI response \\<75) received additional topical therapies or phototherapy beginning at Week 32."
+        }
+      ]
+    },
+    "NCT01212757": {
+      "identifier": "NCT01212757",
+      "briefTitle": "PALACE 2: Efficacy and Safety Study of Apremilast to Treat Active Psoriatic Arthritis",
+      "officialTitle": "A Phase 3, Multicenter, Randomized, Double-blind, Placebo-controlled, Parallel-group, Efficacy and Safety Study of Two Doses of Apremilast (CC-10004) in Subjects With Active Psoriatic Arthritis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2020-05-06",
+      "conditions": [
+        "Psoriatic Arthritis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Apremilast 20mg",
+          "description": "Apremilast 20 mg twice daily, orally"
+        },
+        {
+          "type": "DRUG",
+          "name": "Apremilast 30mg",
+          "description": "Apremilast 30 mg twice daily, orally"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo + 20 mg Apremilast",
+          "description": "Placebo + 20 mg Apremilast"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo + 30 mg Apremilast",
+          "description": "Placebo + 30 mg Apremilast"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Apremilast 20mg",
+          "type": "EXPERIMENTAL",
+          "description": "20 mg Apremilast tablets administered twice daily for 24 weeks during the placebo-controlled phase followed by 20 mg Apremilast tablets administered twice daily for up to 4.5 years in the active treatment / long-term safety phase"
+        },
+        {
+          "label": "Apremilast 30mg",
+          "type": "EXPERIMENTAL",
+          "description": "30 mg Apremilast tablets administered twice a day for 24 weeks during the placebo-controlled phase followed by 30 mg Apremilast tablets administered twice a day for up to 4.5 years in the active treatment / long-term safety phase orally twice daily"
+        },
+        {
+          "label": "Placebo + 20 mg Apremilast",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo + 20 mg Apremilast tablets administered twice daily for 24 weeks during the placebo-controlled phase followed by 20 mg Apremilast tablets administered twice daily for up to 4.5 years in the active treatment / long-term safety phase. Subjects who do not have at least 20% improvement in their swollen and tender joint counts at Week 16 will escape to 20 mg Apremilast twice daily at Week 16"
+        },
+        {
+          "label": "Placebo + 30 mg Apremilast",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo + 30 mg Apremilast tablets administered twice daily for 24 weeks during the placebo-controlled phase followed by 30 mg Apremilast tablets administered twice daily for up to 4.5 years in the active treatment / long-term safety phase. Subjects who do not have at least 20% improvement in their swollen and tender joint counts at Week 16 will escape to 30 mg Apremilast twice daily at Week 16."
+        }
+      ]
+    },
+    "NCT01212770": {
+      "identifier": "NCT01212770",
+      "briefTitle": "PALACE 3: Efficacy and Safety Study of Apremilast to Treat Active Psoriatic Arthritis",
+      "officialTitle": "A Phase 3, Multicenter, Randomized, Double-blind, Placebo-controlled, Parallel-group, Efficacy and Safety Study of Two Doses of Apremilast (CC-10004) in Subjects With Active Psoriatic Arthritis and a Qualifying Psoriasis Lesion",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2020-05-06",
+      "conditions": [
+        "Psoriatic Arthritis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Apremilast 20mg",
+          "description": "Apremilast 20 mg twice daily, orally"
+        },
+        {
+          "type": "DRUG",
+          "name": "Apremilast 30mg",
+          "description": "Apremilast 30 mg twice daily, orally"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": ""
+        }
+      ],
+      "arms": [
+        {
+          "label": "Apremilast 20 mg",
+          "type": "EXPERIMENTAL",
+          "description": "20 mg Apremilast tablets administered twice daily for 24 weeks during the placebo-controlled phase followed by 20 mg Apremilast tablets administered twice daily for up to 4.5 years in the active treatment / long-term safety phase"
+        },
+        {
+          "label": "Apremilast 30 mg",
+          "type": "EXPERIMENTAL",
+          "description": "30 mg Apremilast tablets administered twice a day for 24 weeks during the placebo-controlled phase followed by 30 mg Apremilast tablets administered twice a day for up to 4.5 years in the active treatment / long-term safety phase orally twice daily"
+        },
+        {
+          "label": "Placebo + 20 mg Apremilast",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo + 20 mg Apremilast tablets administered twice daily for 24 weeks during the placebo-controlled phase followed by 20 mg Apremilast tablets administered twice daily for up to 4.5 years in the active treatment / long-term safety phase. Subjects who do not have at least 20% improvement in their swollen and tender joint counts at Week 16 will escape to 20 mg Apremilast twice daily at Week 16"
+        },
+        {
+          "label": "Placebo + 30 mg Apremilast",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo + 30 mg Apremilast tablets administered twice daily for 24 weeks during the placebo-controlled phase followed by 30 mg Apremilast tablets administered twice daily for up to 4.5 years in the active treatment / long-term safety phase. Subjects who do not have at least 20% improvement in their swollen and tender joint counts at Week 16 will escape to 30 mg Apremilast twice daily at Week 16."
+        }
+      ]
+    },
+    "NCT01232283": {
+      "identifier": "NCT01232283",
+      "briefTitle": "Study to Evaluate Safety and Effectiveness of Oral Apremilast (CC-10004) in Patients With Moderate to Severe Plaque Psoriasis.",
+      "officialTitle": "A Phase 3, Multicenter, Randomized, Double-Blind, Placebo-Controlled, Efficacy and Safety Study of Apremilast (CC-10004) in Subjects With Moderate to Severe Plaque Psoriasis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2022-03-15",
+      "conditions": [
+        "Plaque Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Apremilast",
+          "description": "Apremilast 30mg by mouth (PO) twice a day (BID) for 32 weeks"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Identically matching placebo by mouth BID for first 16 weeks. Placebo participants will be switched to receive apremilast 30 mg BID at Week 16-32."
+        },
+        {
+          "type": "OTHER",
+          "name": "Topical or Phototherapy Therapy",
+          "description": "Topical therapies such as low-potency or weak corticosteroids or phototherapies such as light therapy are added for non-responders at Week 32, (\\< PASI-50) and added to their treatment regimen. The decision to add these treatments during this phase can only be made at the Week 32 visit."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Apremilast",
+          "type": "EXPERIMENTAL",
+          "description": "Participants were initially randomized 2:1 and received apremilast 30 mg twice a day (BID). Participants maintained dosing through Week 32. At Week 32, responders, those with a Psoriasis Area Severity Index response -≥75 (PASI-75) and partial responders (≥PASI-50) were re-randomized 1:1 to apremilast 30 mg BID or matching placebo (treatment withdrawal). Participants could resume apremilast 30 mg BID at the time of loss of 50% of improvement in PASI score response which was observed at Week 32 compared to baseline), and no later than Week 52. At Week 52, the non-responders (\\<PASI-50) had the option of adding topical therapies and/or phototherapy to their treatment regimen. Those re-randomized to apremilast 30 mg BID continued dosing through Week 52. At Week 52, participants continued treatment with apremilast 30 mg BID."
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants will be initially randomized to placebo, identically matching during Weeks 0-16. At Week 16, Placebo participants will be switched to receive apremilast 30 mg BID. All participants will maintain Apremilast dosing through Week 32. At Week 32, participants originally randomized to placebo at baseline (Week 0) and are considered non-responders i( \\< PASI-50) will have the option of adding topical therapies and/or phototherapy to their Apremilast treatment regimen. At Week 52, all participants will continue treatment with apremilast 30 mg BID. Participants will be followed and evaluated for safety and efficacy for up to an additional 4 years (years 2 through 5)."
+        }
+      ]
+    },
+    "NCT01264939": {
+      "identifier": "NCT01264939",
+      "briefTitle": "A Safety Study of Xolair (Omalizumab) in Patients With Chronic Idiopathic Urticaria (CIU) Who Remain Symptomatic Despite Treatment With H1 Antihistamines, H2 Blockers, and/or Leukotriene Receptor Antagonists",
+      "officialTitle": "A Phase III, Multicenter, Randomized, Double-blind, Placebo-controlled Safety Study of Xolair (Omalizumab) in Patients With Chronic Idiopathic Urticaria (CIU) Who Remain Symptomatic Despite Treatment With H1 Antihistamines, H2 Blockers, and/or Leukotriene Receptor Antagonists",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2013-11-26",
+      "conditions": [
+        "Chronic Idiopathic Urticaria"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Omalizumab",
+          "description": "Omalizumab was supplied as a lyophilized, sterile powder in a single-use vial."
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Placebo was supplied as a lyophilized, sterile powder in a single-use vial without study drug."
+        },
+        {
+          "type": "DRUG",
+          "name": "H1 antihistamine, H2 antihistamine, leukotriene receptor antagonist",
+          "description": "Participants were required to maintain stable doses of their pre-randomization combination therapy with an H1 antihistamine and either an H2 blocker or leukotriene receptor antagonist, or all 3 drugs in combination, throughout the 24-week treatment period and 16-week follow-up period of the 40-week study."
+        },
+        {
+          "type": "DRUG",
+          "name": "Diphenhydramine",
+          "description": "Participants were provided with diphenhydramine 25 mg for itch relief on an as-needed basis, up to a maximum of 3 doses within 24 hours for the duration of the 40-week study."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants received placebo subcutaneously every 4 weeks during the 24 week treatment period."
+        },
+        {
+          "label": "Omalizumab 300 mg",
+          "type": "EXPERIMENTAL",
+          "description": "Participants received omalizumab 300 mg subcutaneously every 4 weeks during the 24 week treatment period."
+        }
+      ]
+    },
+    "NCT01287117": {
+      "identifier": "NCT01287117",
+      "briefTitle": "A Study of the Efficacy and Safety of Omalizumab (Xolair) in Patients With Chronic Idiopathic Urticaria (CIU)/Chronic Spontaneous Urticaria (CSU) Who Remain Symptomatic Despite Antihistamine (H1) Treatment",
+      "officialTitle": "A Phase III, Multicenter, Randomized, Double-blind, Placebo-controlled, Dose-ranging Study to Evaluate the Efficacy and Safety of Xolair® (Omalizumab) in Patients With Chronic Idiopathic Urticaria (CIU)/Chronic Spontaneous Urticaria (CSU) Who Remain Symptomatic Despite Antihistamine Treatment (H1)",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2013-11-27",
+      "conditions": [
+        "Chronic Idiopathic Urticaria"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Omalizumab",
+          "description": "Omalizumab was supplied as a lyophilized, sterile powder in a single-use vial."
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Placebo was supplied as a lyophilized, sterile powder in a single-use vial without study drug."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants received placebo subcutaneously every 4 weeks during the 24 week treatment period."
+        },
+        {
+          "label": "Omalizumab 75 mg",
+          "type": "EXPERIMENTAL",
+          "description": "Participants received omalizumab 75 mg subcutaneously every 4 weeks during the 24 week treatment period."
+        },
+        {
+          "label": "Omalizumab 150 mg",
+          "type": "EXPERIMENTAL",
+          "description": "Participants received omalizumab 150 mg subcutaneously every 4 weeks during the 24 week treatment period."
+        },
+        {
+          "label": "Omalizumab 300 mg",
+          "type": "EXPERIMENTAL",
+          "description": "Participants received omalizumab 300 mg subcutaneously every 4 weeks during the 24 week treatment period."
+        }
+      ]
+    },
+    "NCT01292473": {
+      "identifier": "NCT01292473",
+      "briefTitle": "A Study to Evaluate the Efficacy, Response Duration and Safety of Xolair (Omalizumab) in Patients With Chronic Idiopathic Urticaria (CIU)/Chronic Spontaneous Urticaria (CSU) Who Remain Symptomatic Despite Antihistamine Treatment (H1)",
+      "officialTitle": "A Phase III, Multicenter, Randomized, Double-blind, Dose-ranging, Placebo-controlled Study to Evaluate the Efficacy, Response Duration and Safety of Xolair (Omalizumab) in Patients With Chronic Idiopathic Urticaria (CIU)/Chronic Spontaneous Urticaria Who Remain Symptomatic Despite Antihistamine Treatment (H1)",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2013-10-11",
+      "conditions": [
+        "Chronic Idiopathic Urticaria"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Placebo was supplied lyophilized in vials."
+        },
+        {
+          "type": "DRUG",
+          "name": "Omalizumab",
+          "description": "Omalizumab was supplied lyophilized in vials."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Placebo",
+          "type": "EXPERIMENTAL",
+          "description": "Placebo subcutaneously (sc) every 4 weeks"
+        },
+        {
+          "label": "Omalizumab 75 mg",
+          "type": "EXPERIMENTAL",
+          "description": "Omalizumab 75 mg sc every 4 weeks"
+        },
+        {
+          "label": "Omalizumab 150 mg",
+          "type": "EXPERIMENTAL",
+          "description": "Omalizumab 150 mg sc every 4 weeks"
+        },
+        {
+          "label": "Omalizumab 300 mg",
+          "type": "EXPERIMENTAL",
+          "description": "Omalizumab 300 mg sc every 4 weeks."
+        }
+      ]
+    },
+    "NCT01295736": {
+      "identifier": "NCT01295736",
+      "briefTitle": "Sildenafil Effect on Digital Ulcer Healing in sClerodErma SEDUCE STUDY",
+      "officialTitle": "Evaluation of the Efficacy of Sildenafil on Time to Healing in Patients With Scleroderma and Ischaemic Digital Ulcers: a Prospective, Longitudinal, Randomized, Comparative, Double-blind, 2-parallel-arm, Placebo-controlled Study",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2026-05-14",
+      "conditions": [
+        "Systemic Scleroderma"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Sildenafil",
+          "description": "Sildenafil 20 mg TID per os during 90 days"
+        },
+        {
+          "type": "DRUG",
+          "name": "placebo",
+          "description": "Placebo pills TID per os during 90 days"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Actif arm",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Sildenafil 20mg TID during 90 days"
+        },
+        {
+          "label": "Sugar pill",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo pills TID during 90 days"
+        }
+      ]
+    },
+    "NCT01358578": {
+      "identifier": "NCT01358578",
+      "briefTitle": "Safety and Efficacy of Secukinumab Compared to Etanercept in Subjects With Moderate to Severe, Chronic Plaque-Type Psoriasis",
+      "officialTitle": "A Randomized, Double-blind, Double-dummy, Placebo Controlled, Multicenter Study of Subcutaneous Secukinumab to Demonstrate Efficacy After Twelve Weeks of Treatment, Compared to Placebo and Etanercept, and to Assess the Safety, Tolerability and Long-term Efficacy up to One Year in Subjects With Moderate to Severe Chronic Plaque-type Psoriasis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2021-01-05",
+      "conditions": [
+        "Chronic Plaque Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Placebo to Match secukinumab (AIN457) 150mg or 300mg or Placebo to match etanercept"
+        },
+        {
+          "type": "DRUG",
+          "name": "secukinumab (AIN457)",
+          "description": "secukinumab (AIN457) 150mg or 300mg subcutaneous"
+        },
+        {
+          "type": "DRUG",
+          "name": "etanercept",
+          "description": "etanercept 50mg subcutaneous"
+        }
+      ],
+      "arms": [
+        {
+          "label": "AIN457 150mg",
+          "type": "EXPERIMENTAL",
+          "description": "AIN457 150mg"
+        },
+        {
+          "label": "AIN457 300mg",
+          "type": "EXPERIMENTAL",
+          "description": "AIN457 300mg"
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo"
+        },
+        {
+          "label": "Etanercept",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Etanercept"
+        },
+        {
+          "label": "AIN457 150mg from Placebo",
+          "type": "EXPERIMENTAL",
+          "description": "Patients randomized to AIN457 150mg in Maintenance phase when they were on Placebo in Induction Phase"
+        },
+        {
+          "label": "AIN457 300mg from Placebo",
+          "type": "EXPERIMENTAL",
+          "description": "Patients randomized to AIN457 300mg in Maintenance phase when they were on Placebo in Induction Phase"
+        }
+      ]
+    },
+    "NCT01365455": {
+      "identifier": "NCT01365455",
+      "briefTitle": "Efficacy and Safety of Subcutaneous Secukinumab for Moderate to Severe Chronic Plaque-type Psoriasis for up to 1 Year",
+      "officialTitle": "A Randomized, Double-blind, Placebo Controlled, Multicenter Study of Subcutaneous Secukinumab to Demonstrate Efficacy After Twelve Weeks of Treatment, and to Assess the Safety, Tolerability and Long-term Efficacy up to One Year in Subjects With Moderate to Severe Chronic Plaque-type Psoriasis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2021-01-05",
+      "conditions": [
+        "Moderate to Severe Plaque-type Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "secukinumab 150 mg",
+          "description": "secukinumab (AIN457) 150mg or 300mg subcutaneous"
+        },
+        {
+          "type": "DRUG",
+          "name": "placebo to secukinumab 150 mg",
+          "description": "Placebo to Match secukinumab (AIN457) 150mg or 300mg subcutaneous"
+        }
+      ],
+      "arms": [
+        {
+          "label": "AIN457 150 mg",
+          "type": "EXPERIMENTAL",
+          "description": "AIN457 secukinumab 150 mg subcutaneous (s.c.) injection plus a placebo secukinumab s.c. injection once weekly for 4 weeks (at randomization, Weeks 1, 2, and 3), followed by dosing every 4 weeks, starting at Week 4 and until Week 48, except for Weeks 13, 14, and 15 when they received two s.c. injections of placebo per week"
+        },
+        {
+          "label": "AIN457 300 mg",
+          "type": "EXPERIMENTAL",
+          "description": "AIN457 secukinumab 300 mg (two s.c. injections of 150 mg) once weekly for 4 weeks (at randomization, Weeks 1, 2, and 3), followed by dosing every 4 weeks, starting at Week 4, and until Week 48, except for Weeks 13, 14, and 15 when they received two s.c. injections of placebo per week"
+        },
+        {
+          "label": "placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "placebo secukinumab (two s.c. injections per dose) once weekly for 4 weeks (at randomization, Weeks 1, 2, and 3), followed by dosing every 4 weeks (Weeks 4 and 8). Prior to receiving the Week 12 dose, all patients in the placebo group were assigned to the following treatment groups based on their PASI 75 response at Week 12. PASI 75 responders: continued on placebo and received their placebo injections at Weeks 12, 13, 14, 15, and then every 4 weeks starting at Week 16 until Week 48."
+        },
+        {
+          "label": "AIN457 150mg from Placebo",
+          "type": "EXPERIMENTAL",
+          "description": "Patients randomized to AIN457 150mg in Maintenance phase when they were on Placebo in Induction Phase because they were PASI 75 non-responders and received their treatment on Weeks 12, 13, 14, 15, and then every 4 weeks starting at Week 16 until Week 48."
+        },
+        {
+          "label": "AIN457 300mg from Placebo",
+          "type": "EXPERIMENTAL",
+          "description": "Patients randomized to AIN457 300mg in Maintenance phase when they were on Placebo in Induction Phase. PASI 75 non-responders and received their treatment on Weeks 12, 13, 14, 15, and then every 4 weeks starting at Week 16 until Week 48."
+        }
+      ]
+    },
+    "NCT01468207": {
+      "identifier": "NCT01468207",
+      "briefTitle": "Efficacy and Safety Study of Adalimumab in Treatment of Hidradenitis Suppurativa",
+      "officialTitle": "A Phase 3 Multicenter Study of the Safety and Efficacy of Adalimumab in Subjects With Moderate to Severe Hidradenitis Suppurativa - PIONEER I",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2021-07-07",
+      "conditions": [
+        "Hidradenitis Suppurativa (HS)"
+      ],
+      "interventions": [
+        {
+          "type": "BIOLOGICAL",
+          "name": "adalimumab",
+          "description": "Adalimumab pre-filled syringe, administered by subcutaneous injection"
+        },
+        {
+          "type": "BIOLOGICAL",
+          "name": "placebo",
+          "description": "Placebo pre-filled syringe, administered by subcutaneous injection"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo for 12 weeks."
+        },
+        {
+          "label": "Adalimumab Every Week (EW)",
+          "type": "EXPERIMENTAL",
+          "description": "Adalimumab ew for 12 weeks (160 mg at Week 0; 80 mg at Week 2; and 40 mg ew from Week 4 to Week 12)."
+        },
+        {
+          "label": "Placebo/Adalimumab Every Week (EW)",
+          "type": "EXPERIMENTAL",
+          "description": "Participants randomized to receive placebo in Period 1 received adalimumab 160 mg at Week 12, 80 mg at Week 14, and 40 mg ew from Week 16 to Week 35 in Period 2 (up to 24 weeks)."
+        },
+        {
+          "label": "Adalimumab Every Week (EW)/Placebo",
+          "type": "EXPERIMENTAL",
+          "description": "Participants randomized to receive adalimumab ew in Period 1 were re-randomized to receive placebo ew from Week 12 to Week 35 in Period 2 (up to 24 weeks)."
+        },
+        {
+          "label": "Adalimumab Every Week (EW)/ Adalimumab Every Other Week (EOW)",
+          "type": "EXPERIMENTAL",
+          "description": "Participants randomized to receive adalimumab ew in Period 1 were re-randomized to receive adalimumab 40 mg eow from Week 12 to Week 35 in Period 2; placebo injections were administered eow from Week 13 to Week 35 (up to 24 weeks)."
+        },
+        {
+          "label": "Adalimumab Every Week (EW)/Adalimumab Every Week (EW)",
+          "type": "EXPERIMENTAL",
+          "description": "Participants randomized to receive adalimumab ew in Period 1 were re-randomized to receive 40 mg adalimumab ew from Week 12 to Week 35 in Period 2 (up to 24 weeks)."
+        }
+      ]
+    },
+    "NCT01468233": {
+      "identifier": "NCT01468233",
+      "briefTitle": "Efficacy and Safety Study of Adalimumab in the Treatment of Hidradenitis Suppurativa",
+      "officialTitle": "A Phase 3 Multicenter Study of the Safety and Efficacy of Adalimumab in Subjects With Moderate to Severe Hidradenitis Suppurativa - PIONEER II",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2021-07-12",
+      "conditions": [
+        "Hidradenitis Suppurativa (HS)"
+      ],
+      "interventions": [
+        {
+          "type": "BIOLOGICAL",
+          "name": "adalimumab",
+          "description": "Adalimumab pre-filled syringe, administered by subcutaneous injection"
+        },
+        {
+          "type": "BIOLOGICAL",
+          "name": "placebo",
+          "description": "Placebo pre-filled syringe, administered by subcutaneous injection"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo for 12 weeks."
+        },
+        {
+          "label": "Adalimumab Every Week (EW)",
+          "type": "EXPERIMENTAL",
+          "description": "Adalimumab ew for 12 weeks (160 mg at Week 0; 80 mg at Week 2; and 40 mg ew from Week 4 to Week 12)."
+        },
+        {
+          "label": "Placebo/Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants randomized to receive placebo in Period 1 received placebo every week from Week 12 to Week 35 in Period 2 (up to 24 weeks)."
+        },
+        {
+          "label": "Adalimumab Every Week (EW)/Placebo",
+          "type": "EXPERIMENTAL",
+          "description": "Participants randomized to receive adalimumab ew in Period 1 were re-randomized to receive placebo ew from Week 12 to Week 35 in Period 2 (up to 24 weeks)."
+        },
+        {
+          "label": "Adalimumab Every Week (EW)/ Adalimumab Every Other Week (EOW)",
+          "type": "EXPERIMENTAL",
+          "description": "Participants randomized to receive adalimumab ew in Period 1 were re-randomized to receive 40 mg adalimumab eow from Week 12 to Week 35 in Period 2; placebo injections were administered eow from Week 13 to Week 35 (up to 24 weeks)."
+        },
+        {
+          "label": "Adalimumab Every Week (EW)/Adalimumab Every Week (EW)",
+          "type": "EXPERIMENTAL",
+          "description": "Participants randomized to receive adalimumab ew in Period 1 were re-randomized to receive 40 mg adalimumab ew from Week 12 to Week 35 in Period 2 (up to 24 weeks)."
+        }
+      ]
+    },
+    "NCT01474512": {
+      "identifier": "NCT01474512",
+      "briefTitle": "A Phase 3 Study in Participants With Moderate to Severe Psoriasis",
+      "officialTitle": "A Multicenter Study With a Randomized, Double-Blind, Placebo-Controlled Induction Dosing Period Followed by a Randomized Maintenance Dosing Period and a Long- Term Extension Period to Evaluate the Efficacy and Safety of LY2439821 in Patients With Moderate-to-Severe Plaque Psoriasis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2019-10-03",
+      "conditions": [
+        "Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "80 mg Ixekizumab Dosing Regimens 1, 2, and 3",
+          "description": "Administered SC"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Administered SC"
+        }
+      ],
+      "arms": [
+        {
+          "label": "80 milligrams (mg) Ixekizumab Dosing Regimen 1 (Q2W)",
+          "type": "EXPERIMENTAL",
+          "description": "Administered as two 80-mg subcutaneous (SC) injections at Week 0, then one 80-mg SC injection per Dosing Regimen 1 \\[every 2 weeks (Q2W)\\] up to and including Week 10. At Week 12, arm is re-randomized to placebo, Dosing Regimen 2 \\[every 4 weeks (Q4W)\\] or Dosing Regimen 3 \\[every 12 weeks Q12W)\\]."
+        },
+        {
+          "label": "80 mg Ixekizumab Dosing Regimen 2 (Q4W)",
+          "type": "EXPERIMENTAL",
+          "description": "Administered as two 80-mg SC injections at Week 0, then one 80-mg SC injection per Dosing Regimen 2 (Q4W) up to and including Week 10. At Week 12, arm is re-randomized to placebo, Dosing Regimen 2 (Q4W) or Dosing Regimen 3 (Q12W)."
+        },
+        {
+          "label": "80 mg Ixekizumab Dosing Regimen 3 (Q12W)",
+          "type": "EXPERIMENTAL",
+          "description": "Dosing Regimen 3 (Q12W) is not used until Week 12. At Week 12, participants who were re-randomized to this arm were administered one 80-mg SC injection Q12W."
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Administered as 2 SC injections at Week 0, then 1 SC injection per Dosing Regimen 1 (Q2W) up to and including Week 10. At Week 12, arm is re-randomized to placebo or Dosing Regimen 2 (Q4W)."
+        }
+      ]
+    },
+    "NCT01532869": {
+      "identifier": "NCT01532869",
+      "briefTitle": "A Study of RoActemra/Actemra (Tocilizumab) Versus Placebo in Patients With Systemic Sclerosis",
+      "officialTitle": "A Phase II/III, Multicenter, Randomized, Double-blind, Placebo-controlled Study To Assess The Efficacy And Safety Of Tocilizumab Versus Placebo In Patients With Systemic Sclerosis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2016-09-23",
+      "conditions": [
+        "Sclerosis, Systemic"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Subcutaneously weekly, Weeks 0-48"
+        },
+        {
+          "type": "DRUG",
+          "name": "tocilizumab [RoActemra/Actemra]",
+          "description": "162 mg subcutaneously weekly, Weeks 0-48"
+        },
+        {
+          "type": "DRUG",
+          "name": "tocilizumab [RoActemra/Actemra]",
+          "description": "162 mg subcutaneously weekly, Week 48-96"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": ""
+        },
+        {
+          "label": "Tocilizumab",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        }
+      ]
+    },
+    "NCT01597050": {
+      "identifier": "NCT01597050",
+      "briefTitle": "Safety and Efficacy of Topical R333 in Patients With Discoid Lupus Erythematosus (DLE) and Systemic Lupus Erythematosus (SLE) Lesions",
+      "officialTitle": "A Phase 2, Multicenter, Randomized, Double-Blind, Placebo-Controlled, Study to Evaluate the Efficacy and Safety of R333 6% Ointment Administered Topically to Discoid Lupus Erythematosus (DLE) and Systemic Lupus Erythematosus (SLE) Patients With Active Cutaneous Discoid Lesions",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2016-07-14",
+      "conditions": [
+        "Lupus Erythematosus, Discoid",
+        "Lupus Erythematosus, Systemic"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "R932333",
+          "description": "R393233 6% (60 mg/g), bid"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Placebo, bid"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Drug: R932333",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "R333 6% (60 mg/g), bid"
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo, bid"
+        }
+      ]
+    },
+    "NCT01597245": {
+      "identifier": "NCT01597245",
+      "briefTitle": "A Phase 3 Study in Participants With Moderate to Severe Psoriasis (UNCOVER-2)",
+      "officialTitle": "A Multicenter, Randomized, Double-Blind, Placebo-Controlled Study Comparing the Efficacy and Safety of LY2439821 to Etanercept and Placebo in Patients With Moderate-to-Severe Plaque Psoriasis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2020-06-26",
+      "conditions": [
+        "Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "80 mg ixekizumab Dosing Regimen",
+          "description": "Administered SC"
+        },
+        {
+          "type": "DRUG",
+          "name": "50 mg etanercept",
+          "description": "Administered SC"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Administered SC"
+        }
+      ],
+      "arms": [
+        {
+          "label": "80 mg ixekizumab Dosing Regimen 1",
+          "type": "EXPERIMENTAL",
+          "description": "Administered by two 80 mg subcutaneous (SC) injections at Week 0, then one 80 mg SC injection per Dosing Regimen 1 until Week 12. At Week 12, ixekizumab responders are re-randomized to placebo, Dosing Regimen 2 or Dosing Regimen 3. Ixekizumab non-responders are assigned to Dosing Regimen 2."
+        },
+        {
+          "label": "80 mg ixekizumab Dosing Regimen 2",
+          "type": "EXPERIMENTAL",
+          "description": "Administered by two 80 mg SC injections at Week 0, then one 80 mg SC injection per Dosing Regimen 2 until Week 12. At Week 12, ixekizumab responders are re-randomized to placebo, Dosing Regimen 2 or Dosing Regimen 3. Ixekizumab non-responders are assigned to Dosing Regimen 2."
+        },
+        {
+          "label": "80 mg ixekizumab Dosing Regimen 3",
+          "type": "EXPERIMENTAL",
+          "description": "Dosing Regimen 3 is not used until Week 12. At Week 12, ixekizumab responders re-randomized to this arm will receive Dosing Regimen 3."
+        },
+        {
+          "label": "50 mg etanercept",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Administered by one 50 mg SC injection twice weekly starting at Week 0 up to Week 12. At Week 12, etanercept responders are assigned to placebo, and nonresponders to Dosing Regimen 2."
+        },
+        {
+          "label": "Placebo for ixekizumab",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo for ixekizumab administered by two SC injections at Week 0, then one SC injection per Dosing Regimen 1 until Week 12. At Week 12, placebo responders are assigned to placebo, and nonresponders to Dosing Regimen 2. Placebo for etanercept administered by one SC injection twice weekly starting at Week 0 up to Week 12 was used to blind etanercept injections for Dosing Regimen 1, Dosing Regimen 2, and Placebo Comparator groups."
+        }
+      ]
+    },
+    "NCT01646177": {
+      "identifier": "NCT01646177",
+      "briefTitle": "A Study in Participants With Moderate to Severe Psoriasis (UNCOVER-3)",
+      "officialTitle": "A 12-Week Multicenter, Randomized, Double-Blind, Placebo-Controlled Study Comparing the Efficacy and Safety of LY2439821 to Etanercept and Placebo in Patients With Moderate to Severe Plaque Psoriasis With a Long-Term Extension Period",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2020-07-28",
+      "conditions": [
+        "Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Administered SC"
+        },
+        {
+          "type": "DRUG",
+          "name": "50 mg etanercept",
+          "description": "Administered SC"
+        },
+        {
+          "type": "DRUG",
+          "name": "80 mg ixekizumab",
+          "description": "Administered SC"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo for ixekizumab administered by two SC injections at Week 0, then one SC injection per Dosing Regimen 1 until Week 12. Placebo for etanercept administered by one SC injection twice weekly starting at Week 0 up to Week 12. At Week 12, participants are assigned to Dosing Regimen 2."
+        },
+        {
+          "label": "50 mg etanercept",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Administered by SC injections twice weekly starting at Week 0 up to Week 12. At Week 12, arm is assigned to Dosing Regimen 2"
+        },
+        {
+          "label": "80 mg ixekizumab Dosing Regimen 2",
+          "type": "EXPERIMENTAL",
+          "description": "Administered by two 80 mg SC injections at Week 0, then one 80 mg SC injection per Dosing Regimen 2 until Week 264."
+        },
+        {
+          "label": "80 mg ixekizumab Dosing Regimen 1",
+          "type": "EXPERIMENTAL",
+          "description": "Administered by two 80 milligram (mg) subcutaneous (SC) injections at Week 0, then one 80 mg SC injection per Dosing Regimen 1 until Week 12. At Week 12, arm is assigned to Dosing Regimen 2."
+        }
+      ]
+    },
+    "NCT01670565": {
+      "identifier": "NCT01670565",
+      "briefTitle": "Belimumab for the Treatment of Diffuse Cutaneous Systemic Sclerosis",
+      "officialTitle": "Belimumab for the Treatment of Diffuse Cutaneous Systemic Sclerosis: A Phase 2a, Single-centered, Randomized, Placebo-controlled, Double-blind, Proof-of-concept Pilot Study.",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2022-05-24",
+      "conditions": [
+        "Systemic Sclerosis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Belimumab",
+          "description": "Belimumab (Benlysta®) decreases B-Cell survival and has been FDA approved for the treatment of systemic lupus erythematosus, another rheumatic autoimmune disease. Belimumab is a recombinant, fully human monoclonal antibody; it binds to the soluble human B lymphocyte stimulator (BLyS) with high affinity and inhibits its biologic activity. Prior research provides a robust rationale for the investigation of belimumab in combination with MMF (Cellcept ®) for the treatment of early diffuse cutaneous systemic sclerosis."
+        },
+        {
+          "type": "DRUG",
+          "name": "Mycophenolate Mofetil",
+          "description": "Patients received background MMF therapy, some who were naive to MMF were titrated up to 1,000 mg twice daily and others had been receiving MMF at \\<2,000 mg/day for \\<3 months. MMF was chosen so that background therapy would be uniform and not a further source of variability in the small study."
+        },
+        {
+          "type": "OTHER",
+          "name": "Placebo Infusion",
+          "description": "Infusion of normal saline"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Mycophenolate mofetil + Belimumab",
+          "type": "EXPERIMENTAL",
+          "description": "All patients who enroll in this trial will FIRST receive mycophenolate mofetil (MMF, Cellcept), which is a drug commonly given to patients with scleroderma in clinical practice. This drug will be given at no cost to the patient. After the patient has been titrated to 2 grams of MMF per day, the patient will receive EITHER a 10 mg/kg belimumab (Benlysta) intravenous infusion OR a placebo (saline) infusion. This medication and infusion will of course be covered by the study."
+        },
+        {
+          "label": "Mycophenolate Mofetil + Saline (placebo)",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "In order to observe the difference between belimumab/MMF compared to MMF alone, half of the patients will receive a normal saline infusion that appears identical to the belimumab infusion."
+        }
+      ]
+    },
+    "NCT01695239": {
+      "identifier": "NCT01695239",
+      "briefTitle": "A Study of Ixekizumab in Participants With Active Psoriatic Arthritis",
+      "officialTitle": "A Multicenter, Randomized, Double-Blind, Active and Placebo-Controlled 24-Week Study Followed by Long Term Evaluation of Efficacy and Safety of Ixekizumab (LY2439821) in Biologic Disease-Modifying Antirheumatic Drug-Naive Patients With Active Psoriatic Arthritis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2019-01-08",
+      "conditions": [
+        "Psoriasis, Arthritic"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Ixekizumab",
+          "description": "Administered SC"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Administered SC"
+        },
+        {
+          "type": "DRUG",
+          "name": "Adalimumab",
+          "description": "Administered SC"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Ixekizumab Q2W",
+          "type": "EXPERIMENTAL",
+          "description": "Administered by 80 milligram (mg) subcutaneous (SC) injection every 2 weeks (Q2W)."
+        },
+        {
+          "label": "Ixekizumab Q4W",
+          "type": "EXPERIMENTAL",
+          "description": "Administered by 80 mg SC injection every 4 weeks (Q4W)."
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo for ixekizumab and placebo for adalimumab administered by SC injection."
+        },
+        {
+          "label": "Adalimumab Q2W",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Administered by 40 mg SC injection Q2W."
+        }
+      ]
+    },
+    "NCT01697267": {
+      "identifier": "NCT01697267",
+      "briefTitle": "Rituximab Vasculitis Maintenance Study",
+      "officialTitle": "An International, Open Label, Randomised Controlled Trial Comparing Rituximab With Azathioprine as Maintenance Therapy in Relapsing ANCA-associated Vasculitis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2022-03-18",
+      "conditions": [
+        "Anti-Neutrophil Cytoplasmic Antibody-Associated Vasculitis",
+        "Microscopic Polyangiitis",
+        "Wegener Granulomatosis"
+      ],
+      "interventions": [
+        {
+          "type": "BIOLOGICAL",
+          "name": "Rituximab",
+          "description": "Rituximab IV infusion 1000 mg x 1 dose at months 4, 8, 12, 16 and 20 and glucocorticoids. Four - six hour infusion. Treatment with rituximab will cease at month 20."
+        },
+        {
+          "type": "DRUG",
+          "name": "Azathioprine",
+          "description": "Oral dosage form. Target dose is 2mg/kg; maximum daily dose is 200mg. This should be continued until month 24. The dose should then by reduced by 50% and azathioprine completely withdrawn at month 27. The dose should be rounded down to the nearest 25mg. The dose may vary on alternate days e.g. 100mg one day, 150mg the next for patients on an overall dose of 125mg daily. If patients are aged over 60 years, reduce the dose by 25%. If patients are aged over 75 years, reduce the dose by 50%."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Rituximab Maintenance",
+          "type": "EXPERIMENTAL",
+          "description": "Rituximab maintenance: 1g at 4, 8, 12, 16 \\& 20 months with standardised steroid taper"
+        },
+        {
+          "label": "Azathioprine Maintenance",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Azathioprine Maintenance: 2mg/kg/day with standardised steroid taper, from month 4 (randomisation) (200 mg maximum daily dose). Azathioprine withdrawn at month 27."
+        }
+      ]
+    },
+    "NCT01705795": {
+      "identifier": "NCT01705795",
+      "briefTitle": "Anti-IL-5 Therapy in Bullous Pemphigoid (BP)",
+      "officialTitle": "Anti-IL-5 Therapy in Bullous Pemphigoid. Randomized, Placebo-controlled, Double-blind Study Evaluating the Effect of Anti-IL-5 Therapy in Patients With Bullous Pemphigoid.",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2017-02-28",
+      "conditions": [
+        "Pemphigoid, Bullous"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Mepolizumab (a-IL-5 antibody)",
+          "description": "750mg mepolizumab four times over four months"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Nacl four times over four months"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Mepolizumab",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Mepolizumab 750 mg four times one month apart."
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo (saline) four times one month apart"
+        }
+      ]
+    },
+    "NCT01708603": {
+      "identifier": "NCT01708603",
+      "briefTitle": "P3 Study Brodalumab in Treatment of Moderate to Severe Plaque Psoriasis",
+      "officialTitle": "A Phase 3 Study to Evaluate the Efficacy and Safety of Induction and Maintenance Regimens of Brodalumab Compared With Placebo and Ustekinumab in Subjects With Moderate to Severe Plaque Psoriasis: AMAGINE-2",
+      "overallStatus": "TERMINATED",
+      "lastUpdatePostDate": "2020-01-06",
+      "conditions": [
+        "Moderate to Severe Plaque Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "210 mg brodalumab",
+          "description": "210 mg brodalumab administered SC"
+        },
+        {
+          "type": "DRUG",
+          "name": "140 mg brodalumab",
+          "description": "140 mg brodalumab administered SC"
+        },
+        {
+          "type": "DRUG",
+          "name": "ustekinumab",
+          "description": "45 mg or 90 mg ustekinumab administered SC per the labeled dosing regimen."
+        },
+        {
+          "type": "DRUG",
+          "name": "placebo",
+          "description": "Placebo administered SC"
+        }
+      ],
+      "arms": [
+        {
+          "label": "210 mg brodalumab",
+          "type": "EXPERIMENTAL",
+          "description": "Administered by subcutaneous (SC) injection until week 12. At week 12, participants are rerandomized to schedule 1, 2, 3, or 4."
+        },
+        {
+          "label": "140 mg brodalumab",
+          "type": "EXPERIMENTAL",
+          "description": "Administered by subcutaneous (SC) injection until week 12. At week 12, participants are rerandomized to schedule 1, 2, 3, or 4."
+        },
+        {
+          "label": "ustekinumab",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Administered by subcutaneous (SC) injection per the labeled dosing regimen."
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Administered by subcutaneous (SC) injection until week 12. At week 12 participants are assigned to 210 mg brodalumab."
+        }
+      ]
+    },
+    "NCT01708629": {
+      "identifier": "NCT01708629",
+      "briefTitle": "Efficacy and Safety of Brodalumab Compared With Placebo and Ustekinumab in Moderate to Severe Plaque Psoriasis Subjects",
+      "officialTitle": "A Phase 3 Study to Evaluate the Efficacy and Safety of Induction and Maintenance Regimens of Brodalumab Compared With Placebo and Ustekinumab in Subjects With Moderate to Severe Plaque Psoriasis: AMAGINE-3",
+      "overallStatus": "TERMINATED",
+      "lastUpdatePostDate": "2020-01-03",
+      "conditions": [
+        "Plaque Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "210 mg brodalumab",
+          "description": "210 mg brodalumab administered SC"
+        },
+        {
+          "type": "DRUG",
+          "name": "140 mg brodalumab",
+          "description": "140 mg brodalumab administered SC"
+        },
+        {
+          "type": "DRUG",
+          "name": "ustekinumab",
+          "description": "45 mg or 90 mg ustekinumab administered SC per the labeled dosing regimen."
+        },
+        {
+          "type": "DRUG",
+          "name": "placebo",
+          "description": "placebo administered SC"
+        }
+      ],
+      "arms": [
+        {
+          "label": "210 mg brodalumab",
+          "type": "EXPERIMENTAL",
+          "description": "Administered by subcutaneous (SC) injection until week 12. At week 12, participants are rerandomized to schedule 1, 2, 3, or 4."
+        },
+        {
+          "label": "140 mg brodalumab",
+          "type": "EXPERIMENTAL",
+          "description": "Administered by subcutaneous (SC) injection until week 12. At week 12, participants are rerandomized to schedule 1, 2, 3, or 4."
+        },
+        {
+          "label": "ustekinumab",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Administered by subcutaneous (SC) injection per the labeled dosing regimen."
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Administered by SC injection until week 12. At week 12 participants are assigned to 210 mg brodalumab."
+        }
+      ]
+    },
+    "NCT01722331": {
+      "identifier": "NCT01722331",
+      "briefTitle": "A Study to Evaluate the Efficacy and Safety of Subcutaneous MK-3222, Followed by an Optional Long-Term Safety Extension Study, in Participants With Moderate-to-Severe Chronic Plaque Psoriasis (MK-3222-010)",
+      "officialTitle": "A 64-Week, Phase 3, Randomized, Placebo-Controlled, Parallel Design Study to Evaluate the Efficacy and Safety/Tolerability of Subcutaneous Tildrakizumab (SCH 900222/MK-3222), Followed by an Optional Long-Term Safety Extension Study, in Subjects With Moderate-to-Severe Chronic Plaque Psoriasis (Protocol No. MK-3222-010)",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2022-03-23",
+      "conditions": [
+        "Plaque Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Tildrakizumab 200 mg",
+          "description": "Two tildrakizumab 100 mg/mL pre-filled syringes (PFS)"
+        },
+        {
+          "type": "DRUG",
+          "name": "Tildrakizumab 100 mg",
+          "description": "Tildrakizumab 100 mg/mL PFS"
+        },
+        {
+          "type": "DRUG",
+          "name": "Matching Placebo",
+          "description": "Matching placebo to tildrakizumab PFS"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Tildrakizumab 200 mg",
+          "type": "EXPERIMENTAL",
+          "description": "Tildrakizumab 200 mg administered subcutaneously (SC) once a week at Weeks 0 and 4 and then every 12 weeks."
+        },
+        {
+          "label": "Tildrakizumab 100 mg",
+          "type": "EXPERIMENTAL",
+          "description": "Tildrakizumab 100 mg administered SC once a week at Weeks 0 and 4 and then every 12 weeks."
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Matching placebo administered SC once a week at Weeks 0 and 4."
+        }
+      ]
+    },
+    "NCT01729754": {
+      "identifier": "NCT01729754",
+      "briefTitle": "A Study to Evaluate the Efficacy and Safety/Tolerability of Subcutaneous Tildrakizumab (SCH 900222/MK-3222) in Participants With Moderate-to-Severe Chronic Plaque Psoriasis Followed by a Long-term Extension Study (MK-3222-011)",
+      "officialTitle": "A 52-Week, Phase 3, Randomized, Active Comparator and Placebo-Controlled, Parallel Design Study to Evaluate the Efficacy and Safety/Tolerability of Subcutaneous Tildrakizumab (SCH 900222/MK-3222), Followed by an Optional Long-Term Safety Extension Study, in Subjects With Moderate-to-Severe Chronic Plaque Psoriasis (Protocol No. MK-3222-011)",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2022-03-08",
+      "conditions": [
+        "Plaque Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Tildrakizumab 200 mg",
+          "description": "Tildrakizumab 200 mg administered SC. Each pre-filled syringe (PFS) or autoinjector (AI) contains 1 mL of solution, tildrakizumab 100 mg/mL."
+        },
+        {
+          "type": "DRUG",
+          "name": "Tildrakizumab 100 mg",
+          "description": "Tildrakizumab 100 mg administered SC. Each PFS or AI contains 1 mL of solution, tildrakizumab 100 mg/mL."
+        },
+        {
+          "type": "DRUG",
+          "name": "Tildrakizumab Placebo",
+          "description": "Matching placebo to tildrakizumab administered SC"
+        },
+        {
+          "type": "DRUG",
+          "name": "Etanercept Placebo",
+          "description": "Matching placebo to etanercept administered SC"
+        },
+        {
+          "type": "DRUG",
+          "name": "Etanercept 50 mg",
+          "description": "Etanercept 50 mg administered SC"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Tildrakizumab 200 mg",
+          "type": "EXPERIMENTAL",
+          "description": "Participants receive tildrakizumab 200 mg subcutaneously (SC) on Weeks 0, 4, 16, 28, 40 and 52 and, optionally, every 12 weeks thereafter until Week 244, plus etanercept placebo (PBO) twice weekly until Week 12 and once weekly from Week 12 to Week 28."
+        },
+        {
+          "label": "Tildrakizumab 100 mg",
+          "type": "EXPERIMENTAL",
+          "description": "Participants receive tildrakizumab 100 mg SC on Weeks 0, 4, 16, 28, 40 and 52 and, optionally, every 12 weeks thereafter until Week 244, plus etanercept placebo twice weekly until Week 12 and once weekly from Week 12 to Week 28."
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants receive matching placebo to tildrakizumab SC on Weeks 0 and 4 plus etanercept placebo twice weekly up to Week 12 and once weekly from Week 12 to Week 28. Participants will be re-randomized 1:1 at Week 12 to receive tildrakizumab 200 mg or tildrakizumab 100 mg on Weeks 12, 16, 28, 40 and 52 and, optionally, every 12 weeks thereafter until Week 244."
+        },
+        {
+          "label": "Etanercept 50 mg",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Participants receive matching placebo to tildrakizumab SC on Weeks 0 and 4 and etanercept 50 mg twice weekly up to Week 12 and once weekly from Week 12 to Week 28. Participants who don't achieve PASI-75, receive tildrakizumab 200 mg after Week 28 (Weeks 32, 36 and 48) and, optionally, every 12 weeks thereafter until Week 244."
+        }
+      ]
+    },
+    "NCT01752634": {
+      "identifier": "NCT01752634",
+      "briefTitle": "Efficacy at 24 Weeks With Long Term Safety, Tolerability and Efficacy up to 5 Years of Secukinumab in Patients of Active Psoriatic Arthritis",
+      "officialTitle": "A Phase III Randomized, Double-blind, Placebo-controlled Multicenter Study of Subcutaneous Secukinumab in Prefilled Syringes to Demonstrate the Efficacy at 24 Weeks and to Assess the Long Term Efficacy, Safety and Tolerability up to 5 Years in Patients With Active Psoriatic Arthritis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2020-05-13",
+      "conditions": [
+        "Psoriatic Arthritis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Secukinumab (AIN457)",
+          "description": "Secukinumab (AIN457)"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Placebo PFS for s.c. administration."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Secukinumab (AIN457) 75 mg s.c.",
+          "type": "EXPERIMENTAL",
+          "description": "Secukinumab 75 mg at BSL, Weeks 1, 2, 3 and 4, followed by dosing every four weeks starting at Week 4."
+        },
+        {
+          "label": "Secukinumab (AIN457) 150 mg s.c.",
+          "type": "EXPERIMENTAL",
+          "description": "Secukinumab 150 mg at BSL, Weeks 1, 2, 3 and 4, followed by dosing every four weeks starting at Week 4."
+        },
+        {
+          "label": "Secukinumab (AIN457) 300 mg s.c.",
+          "type": "EXPERIMENTAL",
+          "description": "Secukinumab 300 mg at BSL, Weeks 1, 2, 3 and 4, followed by dosing every four weeks starting at Week 4"
+        },
+        {
+          "label": "Placebo s.c.",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo at BSL, Weeks 1, 2, 3 and 4, followed by dosing every four weeks starting at Week 4. Non-responder (assessed at Week 16) were re-randomized to receive AIN457 150mg or AIN457 300 mg starting at Week 16. Responder (assessed at Week 16) were re-randomized to receive AIN457 150mg or AIN457 300 mg starting at Week 24."
+        }
+      ]
+    },
+    "NCT01860976": {
+      "identifier": "NCT01860976",
+      "briefTitle": "Efficacy and Safety of Subcutaneous Abatacept in Adults With Active Psoriatic Arthritis",
+      "officialTitle": "A Phase 3 Randomized Placebo-Controlled Study to Evaluate the Efficacy and Safety of Abatacept Subcutaneous Injection in Adults With Active Psoriatic Arthritis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2022-04-05",
+      "conditions": [
+        "Psoriatic Arthritis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Abatacept",
+          "description": ""
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": ""
+        }
+      ],
+      "arms": [
+        {
+          "label": "Abatacept",
+          "type": "EXPERIMENTAL",
+          "description": "Abatacept 125 mg/syringe (125 mg/mL) solution subcutaneously once a week for 168 days double blind/197 days open label/365 days long term extension"
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo matching with Abatacept 0 mg solution subcutaneously once a week 168 days double blind"
+        }
+      ]
+    },
+    "NCT01877668": {
+      "identifier": "NCT01877668",
+      "briefTitle": "Efficacy And Safety Of Tofacitinib In Psoriatic Arthritis: Comparator Study",
+      "officialTitle": "A Phase 3, Randomized, Double-Blind, Placebo-Controlled Study Of The Efficacy And Safety Of 2 Doses Of Tofacitinib (CP-690,550) Or Adalimumab In Subjects With Active Psoriatic Arthritis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2017-07-06",
+      "conditions": [
+        "Psoriatic Arthritis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Tofacitinib 5 mg BID",
+          "description": "Tofacitinib orally (po) 1 tablet of 5 mg and placebo po 1 tablet BID x 12 months Placebo injections subcu every 2 weeks x 12 months"
+        },
+        {
+          "type": "DRUG",
+          "name": "Tofacitinib 10 mg BID",
+          "description": "Tofacitinib po 2 tablets of 5 mg BID x 12 months Placebo injections subcu every 2 weeks x 12 months"
+        },
+        {
+          "type": "DRUG",
+          "name": "Adalimumab",
+          "description": "Placebo po 2 tablets BIDx 12 months Adalimumab 40 mg subcu injections every 2 weeks x 12 months"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Placebo po 2 tablets BIDx 3 months followed by tofacitinib po 1 tablet of 5 mg and placebo po 1 tablet BID x 9 months Placebo injections every 2 weeks x 12 months"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Placebo po 2 tablets BIDx 3 months followed by tofacitinib po 2 tablets (5 mg) BID x 9 months Placebo injections every 2 weeks x 12 months"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Tofacitinib 5 mgBID x 12 months",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        },
+        {
+          "label": "Tofacitinib 10 mg BID x 12 months",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        },
+        {
+          "label": "Adalimumab 40 mg q2 weeks x 12 months",
+          "type": "ACTIVE_COMPARATOR",
+          "description": ""
+        },
+        {
+          "label": "Placebo x3 months, then tofacitinib 5 mg BIDx 9 months",
+          "type": "PLACEBO_COMPARATOR",
+          "description": ""
+        },
+        {
+          "label": "Placebo x 3 months, then tofacitinib 10 mg BID x 9 months",
+          "type": "PLACEBO_COMPARATOR",
+          "description": ""
+        }
+      ]
+    },
+    "NCT01882439": {
+      "identifier": "NCT01882439",
+      "briefTitle": "Tofacitinib In Psoriatic Arthritis Subjects With Inadequate Response to TNF Inhibitors",
+      "officialTitle": "A Phase 3, Randomized, Double-blind, Placebo-controlled Study Of The Efficacy And Safety Of 2 Doses Of Tofacitinib (Cp-690,550) In Subjects With Active Psoriatic Arthritis And An Inadequate Response To At Least One Tnf Inhibitor",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2017-09-15",
+      "conditions": [
+        "Psoriatic Arthritis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Tofacitinib",
+          "description": "tablets, 5 mg BID x 6 months"
+        },
+        {
+          "type": "DRUG",
+          "name": "Tofacitinib",
+          "description": "tablets, 10 mg BID x 6 months"
+        },
+        {
+          "type": "OTHER",
+          "name": "Placebo",
+          "description": "tablets, to match tofacitinib 5 mg BID x 3 months"
+        },
+        {
+          "type": "DRUG",
+          "name": "Tofacitinib",
+          "description": "tablets, 5 mg BID x 3 months"
+        },
+        {
+          "type": "OTHER",
+          "name": "Placebo",
+          "description": "tablets, to match tofacitinib 10 mg BID x 3 months"
+        },
+        {
+          "type": "DRUG",
+          "name": "Tofacitinib",
+          "description": "tablets, 10 mg BID x 3 months"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Treatment Sequence A",
+          "type": "EXPERIMENTAL",
+          "description": "Tofacitinib 5 mg BID for 6 months"
+        },
+        {
+          "label": "Treatment Sequence B",
+          "type": "EXPERIMENTAL",
+          "description": "Tofacitinib 10 mg BID for 6 months"
+        },
+        {
+          "label": "Treatment Sequence C",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo for 3 months then tofacitinib 5 mg BID for 3 months"
+        },
+        {
+          "label": "Treatment Sequence D",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo for 3 months then tofacitinib 10 mg BID for 3 months"
+        }
+      ]
+    },
+    "NCT02020889": {
+      "identifier": "NCT02020889",
+      "briefTitle": "A Study to Investigate Mepolizumab in the Treatment of Eosinophilic Granulomatosis With Polyangiitis",
+      "officialTitle": "A Double-blind, Randomised, Placebo-controlled Study to Investigate the Efficacy and Safety of Mepolizumab in the Treatment of Eosinophilic Granulomatosis With Polyangiitis in Subjects Receiving Standard of Care Therapy",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2018-01-31",
+      "conditions": [
+        "Churg-Strauss Syndrome"
+      ],
+      "interventions": [
+        {
+          "type": "BIOLOGICAL",
+          "name": "Mepolizumab",
+          "description": "Mepolizumab will be provided as a lyophilized cake in sterile vials for individual use to be reconstituted with sterile water for Injection, just prior to use."
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Placebo will be available as 0.9% sodium chloride"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Mepolizumab 300 mg",
+          "type": "EXPERIMENTAL",
+          "description": "Each subject will receive mepolizumab 300 mg subcutaneous (SC) injection every 4 weeks (13 administrations) along with standard care. It will be administered as 3 separate injections (100 mg each- total dose 300 mg); individual injection sites will be separated by at least 5 cm. It will be administered into any of the upper arm, thigh or anterior abdominal wall."
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Each subject will receive placebo (0.9% sodium chloride) SC injection every 4 weeks (13 administrations) along with standard care. It will be administered as 3 separate injections; individual injection sites will be separated by at least 5 cm. It will be administered into any of the upper arm, thigh or anterior abdominal wall."
+        }
+      ]
+    },
+    "NCT02161406": {
+      "identifier": "NCT02161406",
+      "briefTitle": "A Study of Subcutaneous Abatacept to Treat Diffuse Cutaneous Systemic Sclerosis",
+      "officialTitle": "A Phase 2 Study to Evaluate Subcutaneous Abatacept vs. Placebo in Diffuse Cutaneous Systemic Sclerosis- a Double-blind, Placebo-controlled, Randomized Controlled Trial.",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2020-02-17",
+      "conditions": [
+        "Diffuse Cutaneous Systemic Sclerosis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Abatacept",
+          "description": "Subjects will be treated with injections of 125 mg of abatacept or placebo weekly for 52 weeks"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "125 mg of Placebo"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Abatacept",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "125 mg SC abatacept vs SC placebo administered weekly for 12 months, with a 24-week open-label extension"
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "125mg Placebo"
+        }
+      ]
+    },
+    "NCT02207231": {
+      "identifier": "NCT02207231",
+      "briefTitle": "A Study of Guselkumab in the Treatment of Participants With Moderate to Severe Plaque-Type Psoriasis",
+      "officialTitle": "Phase 3, Multicenter, Randomized, Double-blind, Placebo and Active Comparator-controlled Study Evaluating the Efficacy and Safety of Guselkumab in the Treatment of Subjects With Moderate to Severe Plaque-type Psoriasis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2021-07-23",
+      "conditions": [
+        "Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Guselkumab 100 mg",
+          "description": "100 mg by subcutaneous injection at Weeks 0, 4 and q8w thereafter through Week 252 (Group 1). 100 mg by subcutaneous injection at Weeks 16, 20 and q8w thereafter through Week 252 (Group II). 100 mg by subcutaneous injection at Week 52 and q8w thereafter through Week 252 (Group III)."
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo for guselkumab",
+          "description": "Subcutaneous injections to maintain the blind."
+        },
+        {
+          "type": "DRUG",
+          "name": "Adalimumab",
+          "description": "80 mg by subcutaneous injection at Week 0, then 40 mg at Week 1 and every 2 weeks (q2w) thereafter through Week 47."
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo for adalimumab",
+          "description": "Subcutaneous injections to maintain the blind."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Group I",
+          "type": "EXPERIMENTAL",
+          "description": "Participants received Guselkumab 100 milligram (mg) at Weeks 0, 4, and 12 and every 8 weeks (q8w) thereafter through Week 252, placebo for guselkumab at Week 16, and placebo for adalimumab (two 0.8 milliliter \\[mL\\] injections) at Week 0 followed by one 0.8 mL injection at Weeks 1, 3, and 5, and every 2 weeks (q2w) thereafter through Week 47."
+        },
+        {
+          "label": "Group II",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants received Placebo for guselkumab at Weeks 0, 4, and 12, and placebo for adalimumab (two 0.8 mL injections) at Week 0, followed by one 0.8 mL injection at Weeks 1, 3, and 5, and q2w through Week 15. At Week 16, placebo participants will cross over to receive guselkumab 100 mg at Weeks 16 and 20 and q8w thereafter through Week 252, as well as placebo for adalimumab at Weeks 17, 19, 21, and 23, and q2w thereafter through Week 47."
+        },
+        {
+          "label": "Group III",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Participants received Adalimumab 80 mg at Week 0 (two 40 mg \\[0.8 mL\\] injections) and 40 mg at Weeks 1, 3, 5, and q2w thereafter through Week 47, placebo for guselkumab at Weeks 0, 4, 12, 16, and 20, and q8w thereafter through Week 44 and guselkumab 100 mg at Weeks 52, 60, and q8w thereafter through Week 252."
+        }
+      ]
+    },
+    "NCT02207244": {
+      "identifier": "NCT02207244",
+      "briefTitle": "A Study of Guselkumab in the Treatment of Participants With Moderate to Severe Plaque-Type Psoriasis With Randomized Withdrawal and Retreatment",
+      "officialTitle": "A Phase 3, Multicenter, Randomized, Double-blind, Placebo and Active Comparator-controlled Study Evaluating the Efficacy and Safety of Guselkumab for the Treatment of Subjects With Moderate to Severe Plaque-type Psoriasis With Randomized Withdrawal and Retreatment",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2021-07-22",
+      "conditions": [
+        "Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Guselkumab 100 mg",
+          "description": "100 mg by subcutaneous injection at Weeks 0, 4, 12, and 20. Starting at Week 28, participants will continue to receive guselkumab 100 mg through Week 72 depending upon randomized treatment group and PASI response (Group I). 100 mg by subcutaneous injection at Weeks 16 and 20. Starting at Week 28, participants will continue to receive guselkumab 100 mg through Week 72 depending upon PASI response (Group II). Starting at Week 28, participants will receive guselkumab 100 mg through Week 72 depending upon PASI response (Group III). All participants will receive guselkumab q8w starting at Week 76 through Week 252."
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo for guselkumab",
+          "description": "Placebo for guselkumab at Week 16, starting at Week 28, participants will continue to receive placebo for guselkumab through Week 72 depending on randomized treatment group and PASI response (Group I), at weeks 0, 4, 12 and starting at week 28 thereafter up to week 72 depending upon PASI response (Group II), at weeks 0, 4, 12, 16, and 20, starting at week 28 through week 72 depending upon PASI response (Group III)."
+        },
+        {
+          "type": "DRUG",
+          "name": "Adalimumab",
+          "description": "80 mg by subcutaneous injection at Week 0, then 40 mg at Week 1 and every 2 weeks (q2w) thereafter through Week 23."
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo for adalimumab",
+          "description": "Placebo for adalimumab \\[two 0.8 milliliter (mL) injections\\] at week 0 followed by one 0.8 mL injection at weeks 1, 3, 5, and every 2 week (q2w) through Week 23 (Group I and II)."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Group I",
+          "type": "EXPERIMENTAL",
+          "description": "Participants will receive guselkumab 100 milligram (mg) at Weeks 0, 4, 12 and 20. Starting at Week 28, participants will receive guselkumab 100 mg or placebo through Week 72 depending upon randomized treatment group and PASI response. Placebo for guselkumab at Week 16, starting at Week 28, participants will continue to receive placebo for guselkumab through Week 72 depending upon randomized treatment group and PASI response. Placebo for adalimumab \\[two 0.8 milliliter (mL) injections\\] at Week 0 followed by one 0.8 mL injection at Weeks 1, 3, 5, and every 2 week (q2w) through Week 23 to maintain the blind. All participants will receive guselkumab q8w starting at Week 76 through Week 252."
+        },
+        {
+          "label": "Group II",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants will receive placebo for guselkumab at weeks 0, 4, 12 and starting at week 28 thereafter up to week 72 depending upon PASI response. Placebo for adalimumab (two 0.8 mL injections) at week 0, followed by one 0.8 mL injection at weeks 1, 3, and 5, and q2w through week 23. At week 16, placebo participants will cross over to receive guselkumab 100 mg at Weeks 16 and 20, starting at week 28, participants will continue to receive guselkumab 100 mg or placebo through week 72 depending upon PASI response. All participants will received guselkumab q8w starting at Week 76 through Week 252."
+        },
+        {
+          "label": "Group III",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Participants will receive adalimumab 80 mg (two 40 mg \\[0.8 mL\\] injections) at Week 0 followed by adalimumab 40 mg at weeks 1, 3, 5, and q2w through week 23 and placebo for guselkumab at weeks 0, 4, 12, 16, and 20. Participants will receive guselkumab or placebo starting at week 28 through week 72 depending upon PASI response. All participants will received guselkumab q8w starting at Week 76 through Week 252."
+        }
+      ]
+    },
+    "NCT02277743": {
+      "identifier": "NCT02277743",
+      "briefTitle": "Study of Dupilumab Monotherapy Administered to Adult Patients With Moderate-to-Severe Atopic Dermatitis",
+      "officialTitle": "A Phase 3 Confirmatory Study Investigating the Efficacy and Safety of Dupilumab Monotherapy Administered to Adult Patients With Moderate-to-Severe Atopic Dermatitis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2017-11-21",
+      "conditions": [
+        "Dermatitis, Atopic"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Dupilumab",
+          "description": "Subcutaneous injection alternated among the different quadrants of the abdomen, upper thighs and upper arms"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo (for Dupilumab)",
+          "description": "Subcutaneous injection alternated among the different quadrants of the abdomen, upper thighs and upper arms"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Placebo",
+          "type": "EXPERIMENTAL",
+          "description": "Two subcutaneous injections of Placebo (for Dupilumab) as a loading dose on Day 1 followed by a single injection once weekly (qw) from Week 1 to Week 15."
+        },
+        {
+          "label": "Dupilumab 300 mg once weekly (qw)",
+          "type": "EXPERIMENTAL",
+          "description": "Two subcutaneous injections of Dupilumab 300 mg (for a total of 600 mg) as a loading dose on Day 1, followed by a single 300 mg injection of Dupilumab qw from Week 1 to Week 15."
+        },
+        {
+          "label": "Dupilumab 300 mg every 2 weeks (q2w)",
+          "type": "EXPERIMENTAL",
+          "description": "Two subcutaneous injections of Dupilumab 300 mg (for a total of 600 mg) as a loading dose on Day 1, followed by a placebo alternating with single 300 mg injection of Dupilumab qw from Week 1 to Week 15."
+        }
+      ]
+    },
+    "NCT02277769": {
+      "identifier": "NCT02277769",
+      "briefTitle": "Study of Dupilumab (REGN668/SAR231893) Monotherapy Administered to Adult Patients With Moderate-to-Severe Atopic Dermatitis",
+      "officialTitle": "A Phase 3 Confirmatory Study Investigating the Efficacy and Safety of Dupilumab Monotherapy Administered to Adult Patients With Moderate-to-Severe Atopic Dermatitis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2020-06-02",
+      "conditions": [
+        "Dermatitis, Atopic"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Dupilumab",
+          "description": "Subcutaneous injection alternated among the different quadrants of the abdomen, upper thighs and upper arms."
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo (for Dupilumab)",
+          "description": "Subcutaneous injection alternated among the different quadrants of the abdomen, upper thighs and upper arms."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Two subcutaneous injections of Placebo (for Dupilumab) as a loading dose on Day 1 followed by a single injection once weekly (qw) from Week 1 to Week 15."
+        },
+        {
+          "label": "Dupilumab 300 mg every 2 weeks (q2w)",
+          "type": "EXPERIMENTAL",
+          "description": "Two subcutaneous injections of Dupilumab 300 mg (for a total of 600 mg) as a loading dose on Day 1, followed by a placebo alternating with single 300 mg injection of Dupilumab qw from Week 1 to Week 15."
+        },
+        {
+          "label": "Dupilumab 300 mg qw",
+          "type": "EXPERIMENTAL",
+          "description": "Two subcutaneous injections of Dupilumab 300 mg (for a total of 600 mg) as a loading dose on Day 1, followed by a single 300 mg injection of Dupilumab qw from Week 1 to Week 15."
+        }
+      ]
+    },
+    "NCT02283762": {
+      "identifier": "NCT02283762",
+      "briefTitle": "Efficacy and Safety of Riociguat in Patients With Systemic Sclerosis",
+      "officialTitle": "A Randomized, Double-Blind, Placebo-Controlled Phase II Study to Investigate the Efficacy and Safety of Riociguat in Patients With Diffuse Cutaneous Systemic Sclerosis (dcSSc)",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2020-02-05",
+      "conditions": [
+        "Scleroderma, Systemic"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Riociguat (Adempas, BAY63-2521)",
+          "description": "Starting dose 0.5 mg TID, increase by 0.5 mg every 2 weeks until highest possible dose of 2.5 mg TID"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Sham-titration"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Riociguat",
+          "type": "EXPERIMENTAL",
+          "description": "Main treatment phase of 52 weeks: participants received increasing doses of riociguat by 0.5 mg every 2 weeks up to 2.5 mg 3 times a day (TID) in a-titration period of up to 10 weeks and a maintenance period of up to 42 weeks. Long-term extension phase: starting after the completion of the Main Treatment Phase in Week 52, participants received sham-titration in a dose-titration period of up to 10 weeks followed by a maintenance period."
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Main treatment phase of 52 weeks: participants received matching placebo tablets to riociguat as sham titration in a dose-titration period up to 10 weeks and a maintenance period of up to 42 weeks. Long-term extension phase: starting after the completion of the Main Treatment Phase in Week 52, participants received increasing doses of riociguat by 0.5 mg every 2 weeks up to 2.5 mg 3 times a day (TID) in a dose-titration period of up to 10 weeks followed by a maintenance period."
+        }
+      ]
+    },
+    "NCT02307513": {
+      "identifier": "NCT02307513",
+      "briefTitle": "A Phase 3 Randomized, Double-blind Study to Evaluate the Efficacy and Safety of Apremilast (CC-10004) in Subjects With Active Behçet's Disease",
+      "officialTitle": "A Phase 3, Multicenter, Randomized, Doubleblind, Placebo-controlled, Parallel Group Study, Followed by an Active-treatment Phase to Evaluate the Efficacy and Safety of Apremilast (CC-10004) in the Treatment of Subjects With Active Behcet's Disease",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2021-07-22",
+      "conditions": [
+        "Behçet's Syndrome"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Apremilast",
+          "description": "Tablets for oral administration"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Tablets for oral administration"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Placebo / Apremilast",
+          "type": "EXPERIMENTAL",
+          "description": "Participants randomized to this arm will receive placebo tablets twice daily by mouth for the first twelve weeks followed by 52 weeks of 30 mg apremilast tablets twice daily by mouth."
+        },
+        {
+          "label": "Apremilast",
+          "type": "EXPERIMENTAL",
+          "description": "Participants randomized to this arm will receive 30 mg apremilast tablets twice daily by mouth for 64 weeks."
+        }
+      ]
+    },
+    "NCT02349295": {
+      "identifier": "NCT02349295",
+      "briefTitle": "A Study of Ixekizumab (LY2439821) in Participants With Active Psoriatic Arthritis",
+      "officialTitle": "A Multicenter, Randomized, Double-Blind, Placebo Controlled 24-Week Study Followed by Long Term Evaluation of Efficacy and Safety of Ixekizumab (LY2439821) in Biologic Disease-Modifying Antirheumatic Drug-Experienced Patients With Active Psoriatic Arthritis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2020-07-01",
+      "conditions": [
+        "Psoriatic Arthritis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Administered SC"
+        },
+        {
+          "type": "DRUG",
+          "name": "Ixekizumab 80 mg Q4W",
+          "description": "Administered SC"
+        },
+        {
+          "type": "DRUG",
+          "name": "Ixekizumab 80 mg Q2W",
+          "description": "Administered SC"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Ixekizumab 80 milligram (mg) every 2 Weeks (Q2W)",
+          "type": "EXPERIMENTAL",
+          "description": "Blinded Treatment Period (Week(wk) 0-24): Participants (pts) received a starting dose of 160 mg of ixekizumab (ixe) given as 2 subcutaneous (SC) injections at Wk 0 followed by 1 SC injection of 80 mg of ixe Q2W given on Wks 2,4,6,8,10,12,14,16,18,20,22, and 24.Week 16 inadequate responders (IR) from the placebo treatment group who were re-randomized (1:1) to ixe 80 mg Q2W and IR from ixekizumab 80 mg Q2W who continued on ixekizumab 80 mg Q2W. Pts receive rescue therapy while receiving ixekizumab given as 1 injection of 80 mg Q2W given on Wks 16,18,20,22,24. Extension Period (Wk24-156):Pts who were randomized to ixe 80 mg Q2W at week 0 and continued on ixe 80 mg Q2W during the Extension Period. Pts who received ixekizumab 80 mg Q2W,who were either completed the study or discontinued the study early entered the post-treatment follow-up period (12-24 weeks)."
+        },
+        {
+          "label": "Ixekizumab 80 mg Q4W",
+          "type": "EXPERIMENTAL",
+          "description": "Blinded Treatment Period (Week 0-24): Participants (pts) received a starting dose of 160 mg of ixekizumab (ixe) given as 2 subcutaneous (SC) injections at Wk 0 followed by 1 SC injection of 80 mg of ixe Q4W given on Wks 4, 8 and 12 alternating with placebo for ixe injections Q4W given on Wks 2,6,10,14,18, and 22.Week 16 inadequate responders (IR) from the placebo treatment group who were re-randomized (1:1) to ixe 80 mg Q4W and IR from ixekizumab 80 mg Q4W who continued on ixekizumab 80 mg Q4W. Pts receive rescue therapy while receiving ixekizumab given as 1 injection of 80 mg Q4W given on Wks 16 and 20 alternating with placebo for ixe injections Q4W given on Wks 18 and 22.Extension Period (Wk24-156):Pts who were randomized to ixe 80 mg Q4W at week 0 and continued on ixe 80 mg Q4W during the Extension Period.Pts who received ixekizumab 80 mg Q4W,who were either completed the study or discontinued the study early entered the post-treatment follow-up period (12-24 weeks)."
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Blinded Treatment Period (Wk 0-24): Pts received placebo for Ixe as 2 SC injections followed by 1 SC injection Q2W given on Wks 2,4,6,8,10,12,14,16,18,20,22 and 24. Pts initially randomized to placebo treatment group in the double blind treatment period,flagged as IR at Wk 16,re-randomized to ixe 80 mg Q2W/Q4W for the remainder of the current period and following period. Extended Treatment Period (Wk 24-156): Pts who were randomized to placebo at Week 0 then randomized to ixekizumab 80 mg Q2W/Q4W during the Extension Period.Pts who remained on placebo at the completion of the double blind treatment period received the first dose of ixe (160 mg starting dose) at Wk 24.Pts who were IRs at Wk 16 and were re-randomized to ixe at Wk 16 received the first dose of ixe (160 mg starting dose) at Wk 16. Pts who received placebo,who were either completed the study or discontinued the study early entered the post-treatment follow-up period (12-24 weeks)."
+        }
+      ]
+    },
+    "NCT02376790": {
+      "identifier": "NCT02376790",
+      "briefTitle": "Etanercept and Methotrexate in Combination or as Monotherapy in Psoriatic Arthritis",
+      "officialTitle": "A Multicenter Double-Blind, Randomized Controlled Study of Etanercept and Methotrexate in Combination or as Monotherapy in Subjects With Psoriatic Arthritis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2022-09-21",
+      "conditions": [
+        "Psoriatic Arthritis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Etanercept",
+          "description": "Etanercept was administered by subcutaneous injection once a week"
+        },
+        {
+          "type": "DRUG",
+          "name": "Methotrexate",
+          "description": "Methotrexate capsules taken orally once a week. Dosing was initiated at 10 mg weekly and titrated up to a final dose of 20 mg weekly over a 4-week period."
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo to Etanercept",
+          "description": "Placebo to etanercept was administered by subcutaneous injection once a week."
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo to Methotrexate",
+          "description": "Placebo to methotrexate capsules taken orally once a week."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Methotrexate Monotherapy",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Participants received oral methotrexate 20 mg weekly plus placebo to etanercept subcutaneous injection once a week for 48 weeks."
+        },
+        {
+          "label": "Etanercept Monotherapy",
+          "type": "EXPERIMENTAL",
+          "description": "Participants received etanercept 50 mg weekly by subcutaneous injection plus oral placebo to methotrexate for 48 weeks."
+        },
+        {
+          "label": "Methotrexate + Etanercept",
+          "type": "EXPERIMENTAL",
+          "description": "Participants received etanercept 50 mg a week by subcutaneous injection plus oral methotrexate 20 mg weekly for 48 weeks."
+        }
+      ]
+    },
+    "NCT02383589": {
+      "identifier": "NCT02383589",
+      "briefTitle": "A Study to Evaluate the Efficacy and Safety of Rituximab Versus Mycophenolate Mofetil (MMF) in Participants With Pemphigus Vulgaris (PV)",
+      "officialTitle": "A Randomized, Double-Blind, Double-Dummy, Active-Comparator, Multicenter Study to Evaluate the Efficacy and Safety of Rituximab Versus MMF in Patients With Pemphigus Vulgaris",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2020-11-10",
+      "conditions": [
+        "Pemphigus Vulgaris"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Mycophenolate Mofetil Placebo",
+          "description": "MMF matching placebo will be administered orally Q12H."
+        },
+        {
+          "type": "DRUG",
+          "name": "Mycophenolate Mofetil",
+          "description": "MMF will be administered at a starting dose of 500 milligrams (mg) Q12H and the dose will be titrated to achieve a goal of 1 gram (gm) Q12H."
+        },
+        {
+          "type": "DRUG",
+          "name": "Rituximab",
+          "description": "Rituximab will be administered at a dose of 1000 mg via IV infusion."
+        },
+        {
+          "type": "DRUG",
+          "name": "Rituximab Placebo",
+          "description": "Rituximab matching placebo will be administered via IV infusion."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Mycophenolate Mofetil (MMF)",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Participants will receive MMF orally twice daily (every 12 hours, Q12H) from Day 1 to Week 52. Participants will also receive rituximab matching placebo by intravenous (IV) infusion on Days 1 and 15 with repeat administration on Days 168 and 182 provided specific safety criteria have been met."
+        },
+        {
+          "label": "Rituximab (RTX)",
+          "type": "EXPERIMENTAL",
+          "description": "Participants will receive rituximab by IV infusion on Days 1 and 15 with repeat administration on Days 168 and 182 provided specific safety criteria have been met. Participants will also receive MMF matching placebo orally twice daily Q12H from Day 1 to Week 52."
+        }
+      ]
+    },
+    "NCT02446899": {
+      "identifier": "NCT02446899",
+      "briefTitle": "Efficacy and Safety of Anifrolumab Compared to Placebo in Adult Subjects With Active Systemic Lupus Erythematosus",
+      "officialTitle": "A Multicentre, Randomised, Double-blind, Placebo-controlled, Phase 3 Study Evaluating the Efficacy and Safety of Anifrolumab in Adult Subjects With Active Systemic Lupus Erythematosus",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2023-01-10",
+      "conditions": [
+        "Active Systemic Lupus Erythematosus"
+      ],
+      "interventions": [
+        {
+          "type": "BIOLOGICAL",
+          "name": "Anifrolumab",
+          "description": "Intravenous infusion (IV)"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Intravenous infusion (IV)"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Anifrolumab",
+          "type": "EXPERIMENTAL",
+          "description": "Anifrolumab 300 mg intravenous infusion (IV) administered every 4 weeks for a total of 13 doses."
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo intravenous infusion (IV) administered every 4 weeks for a total of 13 doses."
+        }
+      ]
+    },
+    "NCT02446912": {
+      "identifier": "NCT02446912",
+      "briefTitle": "Efficacy and Safety of Two Doses of Anifrolumab Compared to Placebo in Adult Subjects With Active Systemic Lupus Erythematosus",
+      "officialTitle": "A Multicentre, Randomised, Double-blind, Placebo-controlled, Phase 3 Study Evaluating the Efficacy and Safety of Two Doses of Anifrolumab in Adult Subjects With Active Systemic Lupus Erythematosus",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2023-01-12",
+      "conditions": [
+        "Active Systemic Lupus Erythematosus"
+      ],
+      "interventions": [
+        {
+          "type": "BIOLOGICAL",
+          "name": "Anifrolumab",
+          "description": "Anifrolumab IV administration every 4 weeks from Week 0 to Week 48 for a total of 13 doses"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Placebo IV administration every 4 weeks from Week 0 to Week 48"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Anifrolumab - higher dose",
+          "type": "EXPERIMENTAL",
+          "description": "Anifrolumab"
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo"
+        },
+        {
+          "label": "Anifrolumab - lower dose",
+          "type": "EXPERIMENTAL",
+          "description": "Anifrolumab"
+        }
+      ]
+    },
+    "NCT02453256": {
+      "identifier": "NCT02453256",
+      "briefTitle": "A Study of the Efficacy and Safety of Tocilizumab in Participants With Systemic Sclerosis (SSc)",
+      "officialTitle": "A Phase III, Multicenter, Randomized, Double-Blind, Placebo-Controlled, Parallel-Group Study to Assess the Efficacy and Safety of Tocilizumab Versus Placebo in Patients With Systemic Sclerosis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2020-03-09",
+      "conditions": [
+        "Systemic Sclerosis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Participants will receive matching placebo subcutaneous (SC) injections once weekly for 48 weeks of double-blind treatment."
+        },
+        {
+          "type": "DRUG",
+          "name": "Tocilizumab",
+          "description": "Participants will receive 162 mg SC tocilizumab once weekly for 48 weeks of double-blind treatment. The same regimen will be given to all eligible participants for 48 weeks of open-label treatment."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Double-Blind Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants will receive double-blind matching placebo from Baseline to Week 47. Participants may then receive open-label tocilizumab from Weeks 48 to 96."
+        },
+        {
+          "label": "Double-Blind Tocilizumab",
+          "type": "EXPERIMENTAL",
+          "description": "Participants will receive double-blind tocilizumab from Baseline to Week 47. Participants may then receive open-label tocilizumab from Weeks 48 to 96."
+        }
+      ]
+    },
+    "NCT02466243": {
+      "identifier": "NCT02466243",
+      "briefTitle": "Safety, Tolerability, and Efficacy of JBT-101 in Subjects With Dermatomyositis",
+      "officialTitle": "A Phase 2, Double-blind, Randomized, Placebo-controlled Study to Investigate the Safety, Tolerability, and Efficacy of JBT-101 in Subjects With Dermatomyositis",
+      "overallStatus": "TERMINATED",
+      "lastUpdatePostDate": "2023-01-19",
+      "conditions": [
+        "Dermatomyositis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "JBT-101",
+          "description": "Part A: 20 mg once daily on Days 1-28, then 20 mg twice daily on Days 29-84. Part B: JBT-101 20 mg twice daily on Days 1 - 365 of the OLE."
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Part A: Once daily on Days 1-28, then twice daily on Days 29-84. Part B: Placebo twice daily on Days 1 - 365 of the OLE."
+        }
+      ],
+      "arms": [
+        {
+          "label": "JBT-101",
+          "type": "EXPERIMENTAL",
+          "description": "Part A: JBT-101 20 mg capsule once a day on Days 1-28, then 20 mg capsule twice a day on Days 29-84. Part B: JBT-101 20 mg twice daily on Days 1 - 365 of the OLE."
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Part A: Placebo capsule once a day on Days 1-28, then placebo capsule twice a day on Days 29-84. Part B: Placebo twice daily on Days 1 - 365 of the OLE."
+        }
+      ]
+    },
+    "NCT02597933": {
+      "identifier": "NCT02597933",
+      "briefTitle": "A Trial to Compare Nintedanib With Placebo for Patients With Scleroderma Related Lung Fibrosis",
+      "officialTitle": "A Double Blind, Randomised, Placebo-controlled Trial Evaluating Efficacy and Safety of Oral Nintedanib Treatment for at Least 52 Weeks in Patients With Systemic Sclerosis Associated Interstitial Lung Disease (SSc-ILD)",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2019-12-13",
+      "conditions": [
+        "Scleroderma, Systemic"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Nintedanib",
+          "description": ""
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": ""
+        }
+      ],
+      "arms": [
+        {
+          "label": "Nintedanib",
+          "type": "EXPERIMENTAL",
+          "description": "patient receives capsules containing nintedanib twice a day"
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "patient receives capsules identical to those containing active drug"
+        }
+      ]
+    },
+    "NCT02612857": {
+      "identifier": "NCT02612857",
+      "briefTitle": "Trial of IMO-8400 in Adult Patients With Dermatomyositis",
+      "officialTitle": "A Phase 2, Randomized, Double-Blind, Placebo-Controlled Trial of IMO-8400 in Patients With Dermatomyositis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2019-10-10",
+      "conditions": [
+        "Dermatomyositis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "IMO-8400 Dose Group 1",
+          "description": "IMO-8400 Dose 1 subcutaneous injections once a week for 24 weeks."
+        },
+        {
+          "type": "DRUG",
+          "name": "IMO-8400 Dose Group 2",
+          "description": "IMO-8400 Dose 2 subcutaneous injections once a week for 24 weeks."
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "normal saline subcutaneous injections once a week for 24 weeks."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "normal saline subcutaneous injections once a week for 24 weeks."
+        },
+        {
+          "label": "IMO-8400 Dose Group 1",
+          "type": "EXPERIMENTAL",
+          "description": "IMO-8400 Dose Group 1 subcutaneous injections once a week for 24 weeks."
+        },
+        {
+          "label": "IMO-8400 Dose Group 2",
+          "type": "EXPERIMENTAL",
+          "description": "IMO-8400 Dose Group 2 subcutaneous injections once a week for 24 weeks."
+        }
+      ]
+    },
+    "NCT02684357": {
+      "identifier": "NCT02684357",
+      "briefTitle": "BI 655066 Versus Placebo & Active Comparator (Ustekinumab) in Patients With Moderate to Severe Chronic Plaque Psoriasis",
+      "officialTitle": "BI 655066 Versus Ustekinumab and Placebo Comparators in a Randomized Double Blind trIal for Maintenance Use in Moderate to Severe Plaque Type Psoriasis-2 (UltIMMa-2)",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2021-08-23",
+      "conditions": [
+        "Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "risankizumab",
+          "description": "Risankizumab pre-filled syringe, administered by subcutaneous (SC) injection"
+        },
+        {
+          "type": "DRUG",
+          "name": "ustekinumab",
+          "description": "Ustekinumab pre-filled syringe, administered by subcutaneous (SC) injection"
+        },
+        {
+          "type": "DRUG",
+          "name": "placebo for risankizumab",
+          "description": "Placebo for risankizumab pre-filled syringe, administered by subcutaneous (SC) injection"
+        },
+        {
+          "type": "DRUG",
+          "name": "placebo for ustekinumab",
+          "description": "Placebo for ustekinumab pre-filled syringe, administered by subcutaneous (SC) injection"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Placebo (Part A)",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants were randomized to receive double-blind (DB) placebo by subcutaneous (SC) injection at Weeks 0 and 4 (Part A)."
+        },
+        {
+          "label": "Ustekinumab (Part A)",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Participants randomized to receive double-blind (DB) ustekinumab 45 or 90 mg (based on screening weight) by subcutaneous (SC) injection at Weeks 0 and 4 (Part A)."
+        },
+        {
+          "label": "Risankizumab (Part A)",
+          "type": "EXPERIMENTAL",
+          "description": "Participants randomized to receive double-blind (DB) risankizumab 150 mg by subcutaneous (SC) injection at Weeks 0 and 4 (Part A)."
+        }
+      ]
+    },
+    "NCT02684370": {
+      "identifier": "NCT02684370",
+      "briefTitle": "BI 655066 (Risankizumab) Compared to Placebo and Active Comparator (Ustekinumab) in Patients With Moderate to Severe Chronic Plaque Psoriasis",
+      "officialTitle": "BI 655066/ABBV-066 (Risankizumab) Versus Ustekinumab and Placebo Comparators in a Randomized Double Blind trIal for Maintenance Use in Moderate to Severe Plaque Type Psoriasis (UltIMMa-1)",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2021-07-30",
+      "conditions": [
+        "Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "risankizumab",
+          "description": "Risankizumab administered by subcutaneous (SC) injection"
+        },
+        {
+          "type": "DRUG",
+          "name": "placebo for risankizumab",
+          "description": "Placebo for risankizumab administered by subcutaneous (SC) injection"
+        },
+        {
+          "type": "DRUG",
+          "name": "ustekinumab",
+          "description": "Ustekinumab administered by subcutaneous (SC) injection"
+        },
+        {
+          "type": "DRUG",
+          "name": "placebo for ustekinumab",
+          "description": "Placebo for ustekinumab administered by subcutaneous (SC) injection"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Placebo (Part A)",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants randomized to receive double-blind (DB) placebo by subcutaneous (SC) injection at Weeks 0 and 4 (Part A)."
+        },
+        {
+          "label": "Ustekinumab (Part A)",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Participants randomized to receive double-blind (DB) ustekinumab 45 mg or 90 mg (based on screening weight) by subcutaneous (SC) injection at Weeks 0 and 4 (Part A)."
+        },
+        {
+          "label": "Risankizumab (Part A)",
+          "type": "EXPERIMENTAL",
+          "description": "Participants randomized to receive double-blind (DB) risankizumab 150 mg by subcutaneous (SC) injection at Weeks 0 and 4 (Part A)."
+        }
+      ]
+    },
+    "NCT02694523": {
+      "identifier": "NCT02694523",
+      "briefTitle": "BI 655066/ABBV-066 (Risankizumab) Compared to Active Comparator (Adalimumab) in Patients With Moderate to Severe Chronic Plaque Psoriasis",
+      "officialTitle": "BI 655066/ABBV-066 (Risankizumab) Versus Adalimumab in a Randomized, Double Blind, Parallel Group Trial in Moderate to Severe Plaque Psoriasis to Assess Safety and Efficacy After 16 Weeks of Treatment and After Inadequate Adalimumab Treatment Response (IMMvent)",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2021-07-30",
+      "conditions": [
+        "Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "risankizumab",
+          "description": "Risankizumab administered by subcutaneous (SC) injection"
+        },
+        {
+          "type": "BIOLOGICAL",
+          "name": "adalimumab",
+          "description": "Adalimumab pre-filled syringe, administered by subcutaneous (SC) injection"
+        },
+        {
+          "type": "DRUG",
+          "name": "placebo for risankizumab",
+          "description": "Placebo risankizumab administered by subcutaneous (SC) injection"
+        },
+        {
+          "type": "BIOLOGICAL",
+          "name": "placebo for adalimumab",
+          "description": "Placebo for adalimumab pre-filled syringe, administered by subcutaneous (SC) injection"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Adalimumab (Part A)",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Participants randomized to receive double-blind (DB) adalimumab 80 mg by subcutaneous (SC) injection at Week 0, then 40 mg at Week 1 and every 2 weeks for 15 weeks (Part A)."
+        },
+        {
+          "label": "Risankizumab (Part A)",
+          "type": "EXPERIMENTAL",
+          "description": "Participants randomized to receive risankizumab at Weeks 0 and 4 (Part A)."
+        }
+      ]
+    },
+    "NCT02704429": {
+      "identifier": "NCT02704429",
+      "briefTitle": "A Study of PRN1008 in Adult Patients With Pemphigus Vulgaris",
+      "officialTitle": "An Open-Label, Phase 2, Pilot Study Investigating the Safety, Clinical Activity, Pharmacokinetics, and Pharmacodynamics of Oral Treatment With the BTK Inhibitor PRN1008 in Patients With Newly Diagnosed or Relapsing Pemphigus Vulgaris",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2023-02-13",
+      "conditions": [
+        "Pemphigus Vulgaris"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "PRN1008",
+          "description": "Part A dosing was initiated administering 400 mg BID. Intrapatient dose adjustments (reductions and increases) were permitted based upon tolerability and clinical response with the maximum dose allowed up to 600 mg BID for 12 weeks. Part B initial dosing was 400 mg QD for 2 weeks with dose escalation to 400 mg BID at the discretion of the Investigator for the purposes of investigating dose response and identifying the minimal efficacious dose of rilzabrutinib for 24 weeks."
+        }
+      ],
+      "arms": [
+        {
+          "label": "PRN1008",
+          "type": "EXPERIMENTAL",
+          "description": "Part A: Open-label PRN1008, 12 weeks; 12 weeks follow-up; Part B: Open-label PRN1008, 24 weeks; 4 weeks follow-up"
+        }
+      ]
+    },
+    "NCT02728752": {
+      "identifier": "NCT02728752",
+      "briefTitle": "Study Evaluating Efficacy and Safety of Octagam 10% in Patients With Dermatomyositis (Idiopathic Inflammatory Myopathy)",
+      "officialTitle": "Prospective, Double-blind, Randomized, Placebo-Controlled Phase III Study Evaluating Efficacy and Safety of Octagam 10% in Patients With Dermatomyositis (\"ProDERM Study\")",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2021-12-23",
+      "conditions": [
+        "Dermatomyositis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Octagam 10%",
+          "description": "Patients to be treated with Octagam 10%"
+        },
+        {
+          "type": "OTHER",
+          "name": "Placebo",
+          "description": "Patients to be treated with a Placebo"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Subjects randomized to placebo will receive 4 infusions of placebo every 4 weeks during the blinded First Period (16 weeks). If confirmed deterioration (deterioration at 2 consecutive visits) during the First Period, subjects will be switched to Octagam 10%. After response assessment at Week 16, all subjects with no confirmed deterioration and subjects switched to Octagam 10% due to confirmed deterioration but without further confirmed deterioration during the First Period will continue to receive 2.0 g/kg of Octagam 10% every 4 weeks during the subsequent 6-months open-label Extension Period. At Week 28, subjects who are stable on 2.0 g/kg Octagam 10% can be switched to 1.0 g/kg Octagam 10%, at the discretion of the investigator. Subjects randomized to placebo and switched to Octagam 10% due to confirmed deterioration, who deteriorate also during Octagam 10% treatment at 2 consecutive visits will drop-out after response assessment at Week 16 and will not enter the Extension Period."
+        },
+        {
+          "label": "Octagam10%",
+          "type": "EXPERIMENTAL",
+          "description": "Subjects randomized to Octagam will receive 4 infusions of 2.0 g/kg Octagam 10% every 4 weeks during the blinded First Period (16 weeks). If confirmed deterioration (deterioration at 2 consecutive visits) during the First Period, subjects will be switched to the alternate treatment. After response assessment at Week 16, all subjects with no confirmed deterioration during the First Period will continue receiving 2.0 g/kg of Octagam 10% every 4 weeks during the subsequent 6-months open-label Extension Period. At Week 28, subjects who are stable on 2.0 g/kg Octagam 10% can be switched to 1.0 g/kg Octagam 10%, at the discretion of the investigator. Subjects randomized to Octagam and switched to the alternate treatment due to confirmed deterioration will drop-out after response assessment at Week 16 and will not enter the Extension Period."
+        }
+      ]
+    },
+    "NCT02745080": {
+      "identifier": "NCT02745080",
+      "briefTitle": "Efficacy of Secukinumab Compared to Adalimumab in Patients With Psoriatic Arthritis",
+      "officialTitle": "A Randomized, Double-blind, Active Control, Multicenter Study to Evaluate the Efficacy at Week 52 of Secukinumab Monotherapy Compared With Adalimumab Monotherapy in Patients With Active Psoriatic Arthritis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2021-01-27",
+      "conditions": [
+        "Psoriatic Arthritis"
+      ],
+      "interventions": [
+        {
+          "type": "BIOLOGICAL",
+          "name": "Secukinumab",
+          "description": "Eligible subjects are randomized to one of two treatment arms in a 1:1 ratio"
+        },
+        {
+          "type": "BIOLOGICAL",
+          "name": "Adalimumab",
+          "description": "Eligible subjects are randomized to one of two treatment arms in a 1:1 ratio"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Secukinumab 300 mg s.c.",
+          "type": "EXPERIMENTAL",
+          "description": "Secukinumab 300 mg administered at Baseline, Weeks 1, 2, 3 and 4, followed by dosing every 4 weeks until Week 48."
+        },
+        {
+          "label": "Adalimumab 40 mg s.c.",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Adalimumab 40 mg administered at Baseline followed by dosing every 2 weeks until Week 50."
+        }
+      ]
+    },
+    "NCT02847598": {
+      "identifier": "NCT02847598",
+      "briefTitle": "Study to Evaluate BIIB059 (Litifilimab) in Cutaneous Lupus Erythematosus (CLE) With or Without Systemic Lupus Erythematosus (SLE)",
+      "officialTitle": "A 2-Part Phase 2 Randomized, Double-Blind, Placebo-Controlled Study Evaluating the Efficacy and Safety of BIIB059 in Subjects With Systemic Lupus Erythematosus and Active Skin Manifestations and in Subjects With Active Cutaneous Lupus Erythematosus With or Without Systemic Manifestations",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2023-11-07",
+      "conditions": [
+        "Systemic Lupus Erythematosus",
+        "Active Cutaneous Lupus Erythematosus"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "BIIB059 (litifilimab)",
+          "description": "Administered as specified in the treatment arm."
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Administered as specified in the treatment arm."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Part A: BIIB059 450 mg",
+          "type": "EXPERIMENTAL",
+          "description": "BIIB059 450 mg administered SC, Q4W with an additional dose at Week 2 for a total of 7 doses (Weeks 0, 2, 4, 8, 12, 16, and 20) in participants with SLE with active skin manifestations and joint involvement."
+        },
+        {
+          "label": "Part A: Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "BIIB059 matching placebo administered SC, Q4W with an additional dose at Week 2 for total of 7 doses (Weeks 0, 2, 4, 8, 12, 16, and 20) in participants with SLE with active skin manifestations and joint involvement."
+        },
+        {
+          "label": "Part B: BIIB059 50 mg",
+          "type": "EXPERIMENTAL",
+          "description": "BIIB059 50 mg administered SC, Q4W with an additional loading dose at Week 2 for a total of 5 doses (Weeks 0, 2, 4, 8, and 12) in participants with active CLE with or without systemic manifestations."
+        },
+        {
+          "label": "Part B: BIIB059 150 mg",
+          "type": "EXPERIMENTAL",
+          "description": "BIIB059 150 mg administered SC, Q4W with an additional loading dose at Week 2 for a total of 5 doses (Weeks 0, 2, 4, 8, and 12) in participants with active CLE with or without systemic manifestations."
+        },
+        {
+          "label": "Part B: BIIB059 450 mg",
+          "type": "EXPERIMENTAL",
+          "description": "BIIB059 450 mg administered, Q4W with an additional loading dose at Week 2 for a total of 5 doses (Weeks 0, 2, 4, 8, and 12) in participants with active CLE with or without systemic manifestations."
+        },
+        {
+          "label": "Part B: Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "BIIB059 matching placebo administered SC, Q4W with an additional loading dose at Week 2 for a total of 5 doses (Weeks 0, 2, 4, 8, and 12) in participants with active CLE with or without systemic manifestations."
+        }
+      ]
+    },
+    "NCT02902861": {
+      "identifier": "NCT02902861",
+      "briefTitle": "Trial in Patients With Psoriasis Treated With Methotrexate Using an Optimized Treatment Schedule (METOP)",
+      "officialTitle": "An International Prospective, Double-blind, Placebo-controlled Phase III Randomised Controlled Trial (RCT) in Patients With Moderate to Severe Psoriasis Are Treated With Subcutaneous (s.c.) Methotrexate Using an Optimized Treatment Schedule.",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2016-09-16",
+      "conditions": [
+        "Psoriasis Vulgaris"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Methotrexate",
+          "description": "methotrexate 50 mg/ml in syringes for sub-cutaneous injection; Once weekly (every 7 days) s.c. administration of 17.5 mg MTX; If PASI50 is not reached after 8 weeks, the dosing will be increased to 22.5 mg"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo ( for Methotrexate)",
+          "description": "NaCl-Solution manufactured to mimic Methotrexate"
+        }
+      ],
+      "arms": [
+        {
+          "label": "methotrexate",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Once weekly (every 7 days) s.c. administration of 17.5 mg MTX. If PASI50 is not reached after 8 weeks (week 8) or PASI75 is not reached after 24 weeks, the dosing will be increased to 22.5 mg MTX/week. If patients were already dosed with 22.5 mg MTX/week in week 24 and PASI50 is not reached, patients will be excluded from treatment. Primary endpoint after 16 weeks."
+        },
+        {
+          "label": "Placebo (NaCl-Solution)",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Once weekly (every 7 days) s.c. administration of 0.35 mL placebo If PASI50 is not reached after 8 weeks (week 8), the dosing will be increased to 0.45 mL placebo/week. Primary endpoint after 16 weeks. After 16 weeks patients will receive 17.5 mg MTX / week. If PASI50 is not reached after 8 weeks of MTX treatment (week 24), uptitration to 22.5 mg MTX/ 0.45 mL Plac / week will be done. Patients, who will reach PASI75 under placebo treatment after 16 weeks, will be dosed neither with placebo nor with MTX until relapse. After relapse the patients will be dosed with a starting dose of 17.5 mg MTX / week."
+        }
+      ]
+    },
+    "NCT02921971": {
+      "identifier": "NCT02921971",
+      "briefTitle": "Effectiveness and Safety of SAR156597 in Treating Diffuse Systemic Sclerosis",
+      "officialTitle": "Efficacy and Safety of SAR156597 in the Treatment of Diffuse Cutaneous Systemic Sclerosis (dcSSc): A Randomized, Double-blind, Placebo-controlled, 24-week, Proof of Concept Study",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2022-03-21",
+      "conditions": [
+        "Systemic Sclerosis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "SAR156597",
+          "description": "Pharmaceutical form: Solution Route of administration: Subcutaneous"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Pharmaceutical form: Solution Route of administration: Subcutaneous"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo (for SAR156597), single subcutaneous (SC) injection once in a week (QW) up to Week 24."
+        },
+        {
+          "label": "SAR156597",
+          "type": "EXPERIMENTAL",
+          "description": "SAR156597 200 milligram (mg), single SC injection QW up to Week 24."
+        }
+      ]
+    },
+    "NCT02939573": {
+      "identifier": "NCT02939573",
+      "briefTitle": "A Randomized Multicenter Study for Isolated Skin Vasculitis",
+      "officialTitle": "A Randomized Multicenter Study for Isolated Skin Vasculitis",
+      "overallStatus": "RECRUITING",
+      "lastUpdatePostDate": "2026-01-23",
+      "conditions": [
+        "Primary Cutaneous Vasculitis",
+        "Cutaneous Polyarteritis Nodosa",
+        "IgA Vasculitis",
+        "Henoch-Schönlein Purpura"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Colchicine",
+          "description": "Randomized to colchicine 0.6 mg x 2/day"
+        },
+        {
+          "type": "DRUG",
+          "name": "Dapsone",
+          "description": "Randomized to dapsone 150 mg/day"
+        },
+        {
+          "type": "DRUG",
+          "name": "Azathioprine",
+          "description": "Randomized to azathioprine 2 mg/kg/day"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Stage 1",
+          "type": "EXPERIMENTAL",
+          "description": "Eligible patients will be initially randomized (1:1:1) to receive one of the 3 medications under investigation (colchicine 0.6 mg x 2/day; dapsone 150 mg/day; azathioprine 2 mg/kg/day) for 6 months. Endpoint is response to treatment at month 6 (stage 1)."
+        },
+        {
+          "label": "Stage 2",
+          "type": "EXPERIMENTAL",
+          "description": "If the patient has to discontinue the study drug within the (stage 1) 6 month study period or during the subsequent follow-up period (up to month 12) because of a lack of response (or failure), flare or side effect, he/she will be randomized again to receive one of the remaining two study drugs (stage 2, with a 1:1 randomization ratio, colchicine 0.6 mg x 2/day; dapsone 150 mg/day; azathioprine 2 mg/kg/day) for 6 months. Endpoint in this second stage will again be the response to treatment at 6 months."
+        }
+      ]
+    },
+    "NCT02994927": {
+      "identifier": "NCT02994927",
+      "briefTitle": "A Phase 3 Clinical Trial of CCX168 (Avacopan) in Patients With ANCA-Associated Vasculitis",
+      "officialTitle": "A Randomized, Double-Blind, Active-Controlled, Phase 3 Study to Evaluate the Safety and Efficacy of CCX168 (Avacopan) in Patients With ANCA-Associated Vasculitis Treated Concomitantly With Rituximab or Cyclophosphamide/Azathioprine",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2025-03-24",
+      "conditions": [
+        "ANCA-Associated Vasculitis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Avacopan",
+          "description": "Avacopan 30 mg twice daily orally for 52 weeks (364 days): \\- Three 10 mg avacopan capsules in the morning, preferably with food, and three in the evening, preferably with food, approximately 12 hours after the morning dose. Oral prednisone-matching placebo tapering regimen over 20 weeks (140 days): * Prednisone-matching placebo capsules equivalent to 60 mg per day if the subject's body weight was ≥55 kg, or 45 mg per day if the subject's body weight was \\<55 kg, starting on Day 1 with tapering according to a protocol-specified schedule. * Adolescents who weighed ≤37 kg started at a prednisone-matching placebo dose of 30 mg per day."
+        },
+        {
+          "type": "DRUG",
+          "name": "Prednisone",
+          "description": "Avacopan-matching placebo twice daily orally for 52 weeks (364 days): \\- Three avacopan-matching placebo capsules in the morning, preferably with food, and three in the evening, preferably with food, approximately 12 hours after the morning dose. Oral prednisone tapering regimen over 20 weeks (140 days): * Prednisone 60 mg per day if the subject's body weight was ≥55 kg, or 45 mg per day if the subject's body weight was \\<55 kg, starting on Day 1 with tapering according to the protocol-specified schedule. * Adolescents who weighed ≤37 kg started at a prednisone dose of 30 mg per day."
+        },
+        {
+          "type": "DRUG",
+          "name": "Cyclophosphamide",
+          "description": "Orally or intravenously administered"
+        },
+        {
+          "type": "BIOLOGICAL",
+          "name": "Rituximab",
+          "description": "Intravenously administered"
+        },
+        {
+          "type": "DRUG",
+          "name": "Azathioprine",
+          "description": "Orally administered"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Prednisone group",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Avacopan-matching placebo plus cyclophosphamide/azathioprine or rituximab plus a full starting dose of prednisone."
+        },
+        {
+          "label": "Avacopan group",
+          "type": "EXPERIMENTAL",
+          "description": "Avacopan plus cyclophosphamide/azathioprine or rituximab plus prednisone-matching placebo."
+        }
+      ]
+    },
+    "NCT03090100": {
+      "identifier": "NCT03090100",
+      "briefTitle": "A Study to Evaluate the Comparative Efficacy of CNTO 1959 (Guselkumab) and Secukinumab for the Treatment of Moderate to Severe Plaque-type Psoriasis",
+      "officialTitle": "A Phase 3, Multicenter, Randomized, Double-blind Study Evaluating the Comparative Efficacy of CNTO 1959 (Guselkumab) and Secukinumab for the Treatment of Moderate to Severe Plaque-type Psoriasis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2019-10-01",
+      "conditions": [
+        "Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Guselkumab",
+          "description": "Participants will receive 1 injection of active guselkumab at Weeks 0, 4, 12, 20, 28, 36, and 44."
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Participants will receive 1 injection of placebo at Weeks 0, 4, 12, 20, 28, 36, and 44 and 2 injections of placebo at Weeks 1, 2, 3, 8, 16, 24, 32, and 40."
+        },
+        {
+          "type": "DRUG",
+          "name": "Secukinumab",
+          "description": "Participants will receive 2 injections of active secukinumab at Weeks 0, 1, 2, 3, 4 and every 4 weeks (q4w) thereafter through Week 44."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Group I: Guselkumab Plus Placebo",
+          "type": "EXPERIMENTAL",
+          "description": "Participants will receive 1 injection of active guselkumab and 1 injection of placebo when guselkumab is scheduled to be administered (Weeks 0, 4, 12, 20, 28, 36, and 44) or 2 injections of placebo when no guselkumab is scheduled to be administered (Weeks 1, 2, 3, 8, 16, 24, 32, and 40). Placebo injections will be administered to maintain the blind."
+        },
+        {
+          "label": "Group II: Secukinumab",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Participants will receive 2 injections of active secukinumab subcutaneously (SC) at Weeks 0, 1, 2, 3, 4 and every 4 weeks (q4w) thereafter through Week 44."
+        }
+      ]
+    },
+    "NCT03104374": {
+      "identifier": "NCT03104374",
+      "briefTitle": "A Study Comparing Upadacitinib (ABT-494) to Placebo in Participants With Active Psoriatic Arthritis Who Have a History of Inadequate Response to at Least One Biologic Disease Modifying Anti-Rheumatic Drug",
+      "officialTitle": "A Phase 3, Randomized, Double-Blind, Study Comparing Upadacitinib (ABT-494) to Placebo in Subjects With Active Psoriatic Arthritis Who Have a History of Inadequate Response to at Least One Biologic Disease Modifying Anti-Rheumatic Drug (bDMARD)",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2025-09-11",
+      "conditions": [
+        "Psoriatic Arthritis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Oral tablet"
+        },
+        {
+          "type": "DRUG",
+          "name": "Upadacitinib",
+          "description": "Oral tablet"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Upadacitinib 15 mg",
+          "type": "EXPERIMENTAL",
+          "description": "Administered once daily."
+        },
+        {
+          "label": "Placebo / Upadacitinib 30 mg",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Administered once daily."
+        },
+        {
+          "label": "Upadacitinib 30 mg",
+          "type": "EXPERIMENTAL",
+          "description": "Administered once daily."
+        },
+        {
+          "label": "Placebo / Upadacitinib 15 mg",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Administered once daily."
+        }
+      ]
+    },
+    "NCT03104400": {
+      "identifier": "NCT03104400",
+      "briefTitle": "A Study Comparing Upadacitinib (ABT-494) to Placebo and to Adalimumab in Participants With Psoriatic Arthritis Who Have an Inadequate Response to at Least One Non-Biologic Disease Modifying Anti-Rheumatic Drug (DMARD)",
+      "officialTitle": "A Phase 3, Randomized, Double-Blind, Study Comparing Upadacitinib (ABT-494) to Placebo and to Adalimumab in Subjects With Active Psoriatic Arthritis Who Have a History of Inadequate Response to at Least One Non-Biologic Disease Modifying Anti-Rheumatic Drug (DMARD) - SELECT - PsA 1",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2025-09-22",
+      "conditions": [
+        "Psoriatic Arthritis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Adalimumab",
+          "description": "Administered by subcutaneous injection"
+        },
+        {
+          "type": "DRUG",
+          "name": "Upadacitinib",
+          "description": "Oral tablet"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo to Upadacitinib",
+          "description": "Oral tablet"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo to Adalimumab",
+          "description": "Administered by subcutaneous injection"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Upadacitinib 15 mg",
+          "type": "EXPERIMENTAL",
+          "description": "Period 1: Participants receive upadacitinib 15 mg orally once a day (QD) and matching placebo to adalimumab by subcutaneous injection every other week (EOW) for 56 weeks. Period 2: Participants will continue to receive upadacitinib 15 mg once daily."
+        },
+        {
+          "label": "Upadacitinib 30 mg",
+          "type": "EXPERIMENTAL",
+          "description": "Period 1: Participants receive upadacitinib 30 mg orally once a day and matching placebo to adalimumab by subcutaneous injection every other week for 56 weeks. Period 2: Participants will continue to receive upadacitinib 30 mg once daily."
+        },
+        {
+          "label": "Adalimumab",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Period 1: Participants receive adalimumab 40 mg by subcutaneous injection every other week and matching placebo to upadacitinib orally QD for 56 weeks. Period 2: Participants continue to receive adalimumab 40 mg every other week."
+        },
+        {
+          "label": "Placebo / Upadacitinib 15 mg",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Period 1: Participants receive matching placebo to upadacitinib orally once a day for 24 weeks then upadacitinib 15 mg once daily for 32 weeks, and matching placebo to adalimumab by subcutaneous injection EOW for the entire 56 weeks. Period 2: Participants will continue to receive upadacitinib 15 mg once daily."
+        },
+        {
+          "label": "Placebo / Upadacitinib 30 mg",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Period 1: Participants receive matching placebo to upadacitinib orally once a day for 24 weeks then upadacitinib 30 mg once daily for 32 weeks, and matching placebo to adalimumab by subcutaneous injection EOW for the entire 56 weeks. Period 2: Participants will continue to receive upadacitinib 30 mg once daily."
+        }
+      ]
+    },
+    "NCT03158285": {
+      "identifier": "NCT03158285",
+      "briefTitle": "A Study Evaluating the Efficacy and Safety of Guselkumab Administered Subcutaneously in Participants With Active Psoriatic Arthritis",
+      "officialTitle": "A Phase 3, Multicenter, Randomized, Double-blind, Placebo-controlled Study Evaluating the Efficacy and Safety of Guselkumab Administered Subcutaneously in Subjects With Active Psoriatic Arthritis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2026-06-02",
+      "conditions": [
+        "Arthritis, Psoriatic"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Guselkumab",
+          "description": "Participants will receive 100 mg of guselkumab as a sterile liquid for SC injection."
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Participants will receive matching placebo as SC injection."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Group 1: Guselkumab",
+          "type": "EXPERIMENTAL",
+          "description": "Participants will receive subcutaneous (SC) guselkumab 100 milligram (mg) once every 4 weeks (q4w) from Week 0 through Week 100."
+        },
+        {
+          "label": "Group 2: Guselkumab and Placebo",
+          "type": "EXPERIMENTAL",
+          "description": "Participants will receive SC guselkumab 100 mg at Weeks 0 and 4 then once every 8 weeks (q8w) (Weeks 12, 20, 28, 36, 44, 52, 60, 68, 76, 84, 92, and 100) and placebo injections at other visits (Weeks 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, and 96) to maintain the blind."
+        },
+        {
+          "label": "Group 3: Placebo Followed by Guselkumab",
+          "type": "EXPERIMENTAL",
+          "description": "Participants will receive SC placebo q4w from Week 0 to Week 20 and will cross over at Week 24 to receive SC guselkumab 100 mg q4w from Week 24 through Week 100."
+        }
+      ]
+    },
+    "NCT03161483": {
+      "identifier": "NCT03161483",
+      "briefTitle": "A Study to Evaluate the Efficacy and Safety of CC-220 in Subjects With Active Systemic Lupus Erythematosus",
+      "officialTitle": "A PHASE 2, MULTICENTER, RANDOMIZED, DOUBLE-BLIND, PLACEBO-CONTROLLED STUDY TO EVALUATE THE EFFICACY AND SAFETY OF CC-220 IN SUBJECTS WITH ACTIVE SYSTEMIC LUPUS ERYTHEMATOSUS",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2023-06-15",
+      "conditions": [
+        "Lupus Erythematosus, Systemic"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "CC-220",
+          "description": "CC-220"
+        },
+        {
+          "type": "OTHER",
+          "name": "Placebo",
+          "description": "Placebo QD PO"
+        }
+      ],
+      "arms": [
+        {
+          "label": "CC-220 0.45 mg QD Placebo Controlled Phase",
+          "type": "EXPERIMENTAL",
+          "description": "* At Weeks 0 to 24: CC-220 Placebo Controlled Phase: CC-220 0.45 mg once daily (QD) * At Weeks 24 to 52: CC-220 Active Treatment Phase: CC-220 0.45 mg once daily (QD) * Long-term Extension Phase (52 weeks to 104 weeks): At Week 52 all subjects who elect to continue in the Long-term Extension will stay on the same dose they were on at the conclusion of the randomized, double-blind, active treatment phase."
+        },
+        {
+          "label": "C-220 0.3 mg QD Placebo Controlled Phase",
+          "type": "EXPERIMENTAL",
+          "description": "* At Weeks 0 to 24: CC-220 Placebo Controlled Phase: CC-220 0.3 mg once daily (QD) * At Weeks 24 to 52: CC-220 Active Treatment Phase: CC-220 0.30 mg once daily (QD) * Long-term Extension Phase (52 weeks to 104 weeks): At Week 52 all subjects who elect to continue in the Long-term Extension will stay on the same dose they were on at the conclusion of the randomized, double-blind, active treatment phase."
+        },
+        {
+          "label": "CC-220 0.15 mg QD Placebo Controlled Phase",
+          "type": "EXPERIMENTAL",
+          "description": "* At Weeks 0 to 24: CC-220 Placebo Controlled Phase: CC-220 0.15 mg once daily (QD) * At Weeks 24 to 52: CC-220 Active Treatment Phase: CC-220 0.15 mg once daily (QD) * Long-term Extension Phase (52 weeks to 104 weeks): At Week 52 all subjects who elect to continue in the Long-term Extension will stay on the same dose they were on at the conclusion of the randomized, double-blind, active treatment phase."
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Weeks 0 to 24: CC-220 Placebo Controlled Phase: placebo once daily (QD)"
+        }
+      ]
+    },
+    "NCT03162796": {
+      "identifier": "NCT03162796",
+      "briefTitle": "A Study Evaluating the Efficacy and Safety of Guselkumab Administered Subcutaneously in Participants With Active Psoriatic Arthritis Including Those Previously Treated With Biologic Anti -Tumor Necrosis Factor (TNF) Alpha Agent(s)",
+      "officialTitle": "A Phase 3, Multicenter, Randomized, Double-blind, Placebo-controlled Study Evaluating the Efficacy and Safety of Guselkumab Administered Subcutaneously in Subjects With Active Psoriatic Arthritis Including Those Previously Treated With Biologic Anti-TNF Alpha Agents",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2021-02-03",
+      "conditions": [
+        "Arthritis, Psoriatic"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Guselkumab",
+          "description": "Participants will receive 100mg of guselkumab as a sterile liquid for SC injection."
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Participants will receive matching placebo as SC injection."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Group 1: Guselkumab",
+          "type": "EXPERIMENTAL",
+          "description": "Participants will receive subcutaneous (SC) guselkumab 100 milligram (mg) once every 4 weeks (q4w) from Week 0 through Week 48."
+        },
+        {
+          "label": "Group 2: Guselkumab and Placebo",
+          "type": "EXPERIMENTAL",
+          "description": "Participants will receive SC guselkumab 100 mg at Weeks 0 and 4, then once every 8 weeks (q8w) (Weeks 12, 20, 28, 36, and 44) and placebo injections at other visits (Weeks 8, 16, 24, 32, 40, 48) to maintain the blind."
+        },
+        {
+          "label": "Group 3: Placebo Followed by Guselkumab",
+          "type": "EXPERIMENTAL",
+          "description": "Participants will receive SC placebo q4w from Week 0 to Week 20, and will crossover at Week 24 to receive guselkumab 100 mg q4w from Week 24 through Week 48."
+        }
+      ]
+    },
+    "NCT03181893": {
+      "identifier": "NCT03181893",
+      "briefTitle": "A Study In Adults With Moderate To Severe Dermatomyositis",
+      "officialTitle": "A PHASE 2 DOUBLE-BLIND, RANDOMIZED, PLACEBO-CONTROLLED STUDY TO EVALUATE THE EFFICACY, SAFETY, AND TOLERABILITY OF PF-06823859 IN ADULT SUBJECTS WITH DERMATOMYOSITIS",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2023-09-14",
+      "conditions": [
+        "Dermatomyositis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "PF-06823859 low",
+          "description": "A humanized immunoglobulin neutralizing antibody"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo Arm",
+          "description": "Placebo contains histidine, sucrose, PS80, ethylene diamine, and triacetic acid"
+        },
+        {
+          "type": "DRUG",
+          "name": "PF-06823859 high",
+          "description": "A humanized immunoglobulin neutralizing antibody"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Placebo ARM",
+          "type": "PLACEBO_COMPARATOR",
+          "description": ""
+        },
+        {
+          "label": "PF-06823859 ARM high",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        },
+        {
+          "label": "PF-06823859 ARM low",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        }
+      ]
+    },
+    "NCT03252587": {
+      "identifier": "NCT03252587",
+      "briefTitle": "An Investigational Study to Evaluate BMS-986165 in Participants With Systemic Lupus Erythematosus",
+      "officialTitle": "A Phase 2 Randomized, Double-Blind, Placebo-Controlled Study to Evaluate Efficacy and Safety of BMS-986165 in Subjects With Systemic Lupus Erythematosus",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2022-12-20",
+      "conditions": [
+        "Systemic Lupus Erythematosus"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "BMS-986165",
+          "description": "Specified dose on specified days"
+        },
+        {
+          "type": "OTHER",
+          "name": "Placebo",
+          "description": "Specified dose on specified days"
+        }
+      ],
+      "arms": [
+        {
+          "label": "BMS-986165 Dose 1 oral administration",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        },
+        {
+          "label": "BMS-986165 Dose 2 oral administration",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        },
+        {
+          "label": "BMS-986165 Dose 3 oral administration",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        },
+        {
+          "label": "Placebo oral administration",
+          "type": "PLACEBO_COMPARATOR",
+          "description": ""
+        }
+      ]
+    },
+    "NCT03370133": {
+      "identifier": "NCT03370133",
+      "briefTitle": "A Study to Evaluate the Efficacy and Safety of Bimekizumab Compared to Placebo and an Active Comparator in Adult Subjects With Moderate to Severe Chronic Plaque Psoriasis",
+      "officialTitle": "A Phase 3, Multicenter, Randomized, Double-Blind, Placebo- and Active Comparator-Controlled, Parallel-Group Study to Evaluate the Efficacy and Safety of Bimekizumab in Adult Subjects With Moderate to Severe Chronic Plaque Psoriasis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2026-04-15",
+      "conditions": [
+        "Chronic Plaque Psoriasis",
+        "Moderate to Severe Chronic Plaque Psoriasis",
+        "Psoriatic Arthritis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Bimekizumab",
+          "description": "Bimekizumab will be provided at pre-specified time intervals."
+        },
+        {
+          "type": "DRUG",
+          "name": "Ustekinumab",
+          "description": "Ustekinumab will be provided as dose 1 for subjects weighing \\<=100 kg and as dose 2 for subjects weighing \\>100 kg at pre-specified time intervals."
+        },
+        {
+          "type": "OTHER",
+          "name": "Placebo",
+          "description": "Subjects will receive Placebo at pre-specified time points."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Bimekizumab cohort",
+          "type": "EXPERIMENTAL",
+          "description": "Subjects will receive bimekizumab for 52 weeks."
+        },
+        {
+          "label": "Ustekinumab cohort",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Subjects will receive ustekinumab (dose 1 or dose 2 depending on subjects weight) for 52 weeks. Placebo will be administered at pre-specified time points to maintain the blinding."
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Subjects will receive placebo up to week 16 and bimekizumab starting at week 16 through week 52."
+        }
+      ]
+    },
+    "NCT03398837": {
+      "identifier": "NCT03398837",
+      "briefTitle": "Trial to Evaluate Efficacy and Safety of Lenabasum in Diffuse Cutaneous Systemic Sclerosis",
+      "officialTitle": "A Multicenter, Randomized, Double-Blind, Placebo-Controlled Phase 3 Trial to Evaluate Efficacy and Safety of Lenabasum in Diffuse Cutaneous Systemic Sclerosis",
+      "overallStatus": "TERMINATED",
+      "lastUpdatePostDate": "2021-03-29",
+      "conditions": [
+        "Diffuse Cutaneous Systemic Sclerosis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Lenabasum 5 mg",
+          "description": "Subjects will receive lenabasum 5 mg twice daily."
+        },
+        {
+          "type": "DRUG",
+          "name": "Lenabasum 20 mg",
+          "description": "Subjects will receive lenabasum 20 mg twice daily."
+        },
+        {
+          "type": "OTHER",
+          "name": "Placebo oral capsule",
+          "description": "Subjects will receive placebo twice daily."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Cohort 1",
+          "type": "EXPERIMENTAL",
+          "description": "Lenabasum 5 mg BID"
+        },
+        {
+          "label": "Cohort 2",
+          "type": "EXPERIMENTAL",
+          "description": "Lenabasum 20 mg BID"
+        },
+        {
+          "label": "Cohort 3",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo BID"
+        }
+      ]
+    },
+    "NCT03412747": {
+      "identifier": "NCT03412747",
+      "briefTitle": "A Study to Evaluate the Efficacy and Safety of Bimekizumab in Adult Subjects With Moderate to Severe Chronic Plaque Psoriasis",
+      "officialTitle": "A Phase 3, Multicenter, Randomized, Double-Blind Study With an Active-Controlled Initial Treatment Period Followed by a Dose-Blind Maintenance Treatment Period to Evaluate the Efficacy and Safety of Bimekizumab in Adult Subjects With Moderate to Severe Chronic Plaque Psoriasis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2026-04-15",
+      "conditions": [
+        "Chronic Plaque Psoriasis",
+        "Moderate to Severe Plaque Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Bimekizumab",
+          "description": "Subjects will receive bimekizumab at pre-defined timepoints in dose regimen 1 and/or dose regimen 2."
+        },
+        {
+          "type": "DRUG",
+          "name": "Adalimumab",
+          "description": "Adalimumab will be administered according to the labeling recommendations."
+        },
+        {
+          "type": "OTHER",
+          "name": "Placebo",
+          "description": "Subjects will receive Placebo at pre-specified time points to maintain the blinding of the Investigational Medicinal Products (IMP)."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Bimekizumab Arm 1",
+          "type": "EXPERIMENTAL",
+          "description": "Subjects will receive bimekizumab dose regimen 1 for 56 weeks. Subjects will receive placebo at pre-specified time-points to maintain the blinding."
+        },
+        {
+          "label": "Bimekizumab Arm 2",
+          "type": "EXPERIMENTAL",
+          "description": "Subjects will receive bimekizumab dose regimen 1 for 16 weeks and will proceed with bimekizumab dose regimen 2 until week 56. Subjects will receive placebo at pre-specified time-points to maintain the blinding."
+        },
+        {
+          "label": "Adalimumab Arm",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Subjects will receive adalimumab for 24 weeks and will then receive bimekizumab dose regimen 1 until week 56. Subjects will receive placebo at pre-specified time-points to maintain the blinding."
+        }
+      ]
+    },
+    "NCT03536884": {
+      "identifier": "NCT03536884",
+      "briefTitle": "A Study to Evaluate the Efficacy and Safety of Bimekizumab Compared to an Active Comparator in Adult Subjects With Moderate to Severe Chronic Plaque Psoriasis",
+      "officialTitle": "A Multicenter, Randomized, Double-Blind, Secukinumab-Controlled, Parallel-Group Study to Evaluate the Efficacy and Safety of Bimekizumab in Adult Subjects With Moderate to Severe Chronic Plaque Psoriasis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2026-04-15",
+      "conditions": [
+        "Chronic Plaque Psoriasis",
+        "Moderate to Severe Chronic Plaque Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Bimekizumab",
+          "description": "Subjects will receive bimekizumab at pre-specified time-points."
+        },
+        {
+          "type": "DRUG",
+          "name": "Secukinumab",
+          "description": "Subjects will receive secukinumab at pre-specified time-points."
+        },
+        {
+          "type": "OTHER",
+          "name": "Placebo",
+          "description": "Subjects will receive placebo at pre-specified time-points to maintain the blinding in the double-blind Treatment Period."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Bimekizumab dosage regimen 1",
+          "type": "EXPERIMENTAL",
+          "description": "Subjects randomized to this arm will receive bimekizumab dosage regimen 1 (BKZ 1). At Week 16 subjects will be re-randomized and continue to receive BKZ 1 or to switch to bimekizumab regimen 2 (BKZ 2). Placebo will be administered at pre-specified time-points to maintain the blinding over the double-blind Treatment Period. Subjects allowed to enroll in the open-label extension (OLE) Period will receive BKZ 1 or BKZ 2. Subjects will switch from BKZ 1 to BKZ 2 at Week 64 or at the next scheduled Visit. Eligible subjects who completed OLE, have entered Safety Follow Up (SFU) or completed SFU would start OLE2 on BKZ 1 before switching to BKZ 2 after 16 weeks or start OLE2 on BKZ 2."
+        },
+        {
+          "label": "Bimekizumab dosage regimen 2",
+          "type": "EXPERIMENTAL",
+          "description": "Subjects randomized to this arm will receive bimekizumab dosage regimen 2 (BKZ 2) starting at Week 16 after initial treatment on bimekizumab regimen 1 (BKZ 1) for 16 weeks. Placebo will be administered at pre-specified time-points to maintain the blinding over the double-blind Treatment Period. Subjects allowed to enroll in the open-label extension (OLE) Period will receive BKZ 1 or BKZ 2. Subjects will switch from BKZ 1 to BKZ 2 at Week 64 or at the next scheduled Visit. Eligible subjects who completed OLE, have entered SFU or completed SFU would start OLE2 on BKZ 1 before switching to BKZ 2 after 16 weeks or start OLE2 on BKZ 2."
+        },
+        {
+          "label": "Secukinumab",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Subjects will receive secukinumab. Subjects allowed to enroll in the open-label extension (OLE) Period will be re-randomized to receive bimekizumab dosage regimen 1 (BKZ 1) or bimekizumab dosage regimen 2 (BKZ 2). Eligible subjects who completed OLE, have entered SFU or completed SFU would start OLE2 on BKZ 1 before switching to BKZ 2 after 16 weeks or start OLE2 on BKZ 2."
+        }
+      ]
+    },
+    "NCT03570749": {
+      "identifier": "NCT03570749",
+      "briefTitle": "A Study of Baricitinib (LY3009104) in Participants With Severe or Very Severe Alopecia Areata",
+      "officialTitle": "A Multicenter, Randomized, Double-Blind, Placebo-Controlled, Operationally Seamless, Adaptive Phase 2/3 Study to Evaluate the Efficacy and Safety of Baricitinib in Adult Patients With Severe or Very Severe Alopecia Areata",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2026-04-16",
+      "conditions": [
+        "Alopecia Areata"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Baricitinib",
+          "description": "Administered orally."
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Administered orally."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Placebo Phase 2",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants received three placebo tablets administered orally once daily (QD). Rescue therapy with Baricitinib 2 mg or 4 mg was provided to participants who failed to achieve Severity of Alopecia Tool (SALT) ≤20 (less than or equal to 20) during the study period."
+        },
+        {
+          "label": "1 Milligram (mg) / 4 mg Baricitinib Phase 2",
+          "type": "EXPERIMENTAL",
+          "description": "Participants received one 1 mg baricitinib tablet administered orally QD and two placebo tablets administered orally QD to maintain the blind through Week 12. Following the decision point at Week 12, participants were transitioned to receive one 4 mg baricitinib tablet administered orally QD and two placebo tablets administered orally QD to maintain the blind, and continued treatment through Week 200."
+        },
+        {
+          "label": "2 mg Baricitinib Phase 2",
+          "type": "EXPERIMENTAL",
+          "description": "Participants received one 2 mg Baricitinib tablet administered orally QD, and two placebo tablets administered orally QD to maintain the blind."
+        },
+        {
+          "label": "4 mg Baricitinib Phase 2",
+          "type": "EXPERIMENTAL",
+          "description": "Participants received one 4 mg Baricitinib tablet administered orally, QD and two placebo tablets QD administered orally to maintain the blind."
+        },
+        {
+          "label": "Placebo Phase 3",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants received two placebo tablets administered orally QD. Rescue therapy with Baricitinib 2 mg or 4 mg was provided to participants who failed to achieve SALT≤20 during this treatment period."
+        },
+        {
+          "label": "2 mg Baricitinib Phase 3",
+          "type": "EXPERIMENTAL",
+          "description": "Participants received one 2 mg Baricitinib tablet administered orally QD, and one placebo tablet administered orally QD to maintain the blind."
+        },
+        {
+          "label": "4 mg Baricitinib Phase 3",
+          "type": "EXPERIMENTAL",
+          "description": "Participants received one 4 mg Baricitinib tablet administered orally QD, and one placebo tablet administered orally QD to maintain the blind."
+        },
+        {
+          "label": "Placebo/ Placebo Phase 3",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants who received two placebo tablets administered orally QD in Period 1 continue to receive the same placebo in Period 2."
+        },
+        {
+          "label": "Placebo/ 2 mg Baricitinib Phase 3",
+          "type": "EXPERIMENTAL",
+          "description": "Participants who received Placebo at Period 1 switched to receive 2 mg Baricitinib dose administered orally QD in Period 2."
+        },
+        {
+          "label": "Placebo/ 4 mg Baricitinib Phase 3",
+          "type": "EXPERIMENTAL",
+          "description": "Participants who received Placebo at Period 1 switched to receive 4 mg Baricitinib dose administered orally QD in Period 2."
+        },
+        {
+          "label": "2 mg Baricitinib /2 mg Baricitinib Phase 3",
+          "type": "EXPERIMENTAL",
+          "description": "Participants who received 2 mg Baricitinib at Period 1 continued to receive 2 mg Baricitinib dose administered orally QD in Period 2."
+        },
+        {
+          "label": "2 mg Baricitinib /4 mg Baricitinib Phase 3",
+          "type": "EXPERIMENTAL",
+          "description": "Participants who received 2 mg Baricitinib at Period 1 switched to receive 4 mg Baricitinib dose administered orally QD in Period 2."
+        },
+        {
+          "label": "2 mg Baricitinib / Placebo Phase 3",
+          "type": "EXPERIMENTAL",
+          "description": "Participants who received 2 mg Baricitinib at Period 1 switched to receive Placebo administered orally QD in Period 2."
+        },
+        {
+          "label": "4 mg Baricitinib / Placebo Phase 3",
+          "type": "EXPERIMENTAL",
+          "description": "Participants who received 4 mg Baricitinib at Period 1 switched to receive Placebo administered orally QD in Period 2."
+        },
+        {
+          "label": "4 mg Baricitinib /4 mg Baricitinib Phase 3",
+          "type": "EXPERIMENTAL",
+          "description": "Participants who received 4 mg Baricitinib at Period 1 continued to receive 4 mg Baricitinib administered orally QD in Period 2."
+        },
+        {
+          "label": "4 mg Baricitinib Phase 3 Open-Label Addendum",
+          "type": "EXPERIMENTAL",
+          "description": "Participants who received one 4 mg Baricitinib tablet administered orally QD."
+        }
+      ]
+    },
+    "NCT03611751": {
+      "identifier": "NCT03611751",
+      "briefTitle": "An Investigational Study to Evaluate Experimental Medication BMS-986165 Compared to Placebo and a Currently Available Treatment in Participants With Moderate-to-Severe Plaque Psoriasis",
+      "officialTitle": "A Multi-Center, Randomized, Double-Blind, Placebo- and Active Comparator-Controlled Phase 3 Study With Randomized Withdrawal and Retreatment to Evaluate the Efficacy and Safety of BMS-986165 in Subjects With Moderate-to-Severe Plaque Psoriasis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2022-12-20",
+      "conditions": [
+        "Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "BMS-986165",
+          "description": "Specified dose on specified days"
+        },
+        {
+          "type": "OTHER",
+          "name": "Placebo",
+          "description": "Specified dose on specified days"
+        },
+        {
+          "type": "DRUG",
+          "name": "Apremilast",
+          "description": "Specified dose on specified days"
+        }
+      ],
+      "arms": [
+        {
+          "label": "BMS-986165",
+          "type": "EXPERIMENTAL",
+          "description": "BMS-986165 oral administration"
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo oral administration"
+        },
+        {
+          "label": "Active comparator",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Active comparator oral administration"
+        }
+      ]
+    },
+    "NCT03624127": {
+      "identifier": "NCT03624127",
+      "briefTitle": "Effectiveness and Safety of BMS-986165 Compared to Placebo and Active Comparator in Participants With Psoriasis",
+      "officialTitle": "A Multi-Center, Randomized, Double-Blind, Placebo- and Active Comparator-Controlled Phase 3 Study to Evaluate the Efficacy and Safety of BMS-986165 in Subjects With Moderate-to-Severe Plaque Psoriasis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2023-01-30",
+      "conditions": [
+        "Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "BMS-986165",
+          "description": "Specified dose on specified days"
+        },
+        {
+          "type": "OTHER",
+          "name": "Placebo",
+          "description": "Specified dose on specified days"
+        },
+        {
+          "type": "DRUG",
+          "name": "Apremilast",
+          "description": "Specified dose on specified days"
+        }
+      ],
+      "arms": [
+        {
+          "label": "BMS-986165",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": ""
+        },
+        {
+          "label": "Apremilast",
+          "type": "ACTIVE_COMPARATOR",
+          "description": ""
+        }
+      ]
+    },
+    "NCT03671148": {
+      "identifier": "NCT03671148",
+      "briefTitle": "A Study Comparing Risankizumab to Placebo in Participants With Active Psoriatic Arthritis Including Those Who Have a History of Inadequate Response or Intolerance to Biologic Therapy(Ies)",
+      "officialTitle": "A Phase 3, Randomized, Double-Blind Study Comparing Risankizumab to Placebo in Subjects With Active Psoriatic Arthritis Including Those Who Have a History of Inadequate Response or Intolerance to Biologic Therapy(Ies) (KEEPsAKE 2)",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2026-07-20",
+      "conditions": [
+        "Psoriatic Arthritis (PsA)"
+      ],
+      "interventions": [
+        {
+          "type": "BIOLOGICAL",
+          "name": "Placebo",
+          "description": "Placebo for risankizumab administered by subcutaneous (SC) injection"
+        },
+        {
+          "type": "BIOLOGICAL",
+          "name": "Risankizumab",
+          "description": "Risankizumab administered by subcutaneous (SC) injection"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Risankizumab",
+          "type": "EXPERIMENTAL",
+          "description": "Participants randomized to receive 150 mg risankizumab administered by subcutaneous injection at Week 0, Week 4, and Week 16 in Period 1. At Week 24 participants will receive blinded placebo followed by open-label 150 mg risankizumab at Week 28, and every 12 weeks thereafter in Period 2 until the final dosing time point at Week 316."
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants randomized to receive double-blind placebo at Week 0, Week 4, and Week 16 in Period 1. At Week 24 participants will receive 150 mg risankizumab followed by open-label 150 mg risankizumab at Week 28, and every 12 weeks thereafter in Period 2 until the final dosing time point at Week 316."
+        }
+      ]
+    },
+    "NCT03675308": {
+      "identifier": "NCT03675308",
+      "briefTitle": "A Study Comparing Risankizumab to Placebo in Participants With Active Psoriatic Arthritis (PsA) Who Have a History of Inadequate Response to or Intolerance to at Least One Disease Modifying Anti-Rheumatic Drug (DMARD) Therapy",
+      "officialTitle": "A Phase 3, Randomized, Double-Blind, Study Comparing Risankizumab to Placebo in Subjects With Active Psoriatic Arthritis (PsA) Who Have a History of Inadequate Response to or Intolerance to at Least One Disease Modifying Anti-Rheumatic Drug (DMARD) Therapy (KEEPsAKE 1)",
+      "overallStatus": "ACTIVE_NOT_RECRUITING",
+      "lastUpdatePostDate": "2025-08-05",
+      "conditions": [
+        "Psoriatic Arthritis"
+      ],
+      "interventions": [
+        {
+          "type": "BIOLOGICAL",
+          "name": "Placebo",
+          "description": "Placebo for risankizumab administered by subcutaneous injection"
+        },
+        {
+          "type": "BIOLOGICAL",
+          "name": "Risankizumab",
+          "description": "Risankizumab administered by subcutaneous injection"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants randomized to receive double-blind placebo at Week 0, Week 4, and Week 16 in Period 1. At Week 24 participants will receive 150 mg risankizumab followed by open-label 150 mg risankizumab at Week 28, and every 12 weeks thereafter in Period 2 until the final dosing time point at Week 316."
+        },
+        {
+          "label": "Risankizumab",
+          "type": "EXPERIMENTAL",
+          "description": "Participants randomized to receive 150 mg risankizumab administered by subcutaneous injection at Week 0, Week 4, and Week 16 in Period 1. At Week 24 participants will receive blinded placebo followed by open-label 150 mg risankizumab at Week 28, and every 12 weeks thereafter in Period 2 until the final dosing time point at Week 316."
+        }
+      ]
+    },
+    "NCT03713619": {
+      "identifier": "NCT03713619",
+      "briefTitle": "This Was a Study of Efficacy and Safety of Two Secukinumab Dose Regimens in Subjects With Moderate to Severe Hidradenitis Suppurativa (HS).",
+      "officialTitle": "A Randomized, Double-blind, Multi-center Study Assessing Short (16 Weeks) and Long-term Efficacy (up to 1 Year), Safety, and Tolerability of 2 Subcutaneous Secukinumab Dose Regimens in Adult Patients With Moderate to Severe Hidradenitis Suppurativa (SUNSHINE).",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2024-10-09",
+      "conditions": [
+        "Hidradenitis Suppurativa"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "secukinumab",
+          "description": "Secukinumab 300mg every 2 or every 4 weeks"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Placebo 300mg every 2 or every 4 weeks"
+        }
+      ],
+      "arms": [
+        {
+          "label": "secukinumab 1",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Secukinumab 300mg every 2 weeks"
+        },
+        {
+          "label": "secukinumab 2",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Secukinumab 300mg every 4 weeks"
+        },
+        {
+          "label": "placebo 1",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo group to secukinumab 300mg every 2 weeks"
+        },
+        {
+          "label": "placebo 2",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo group to secukinumab 300mg every 4 weeks"
+        }
+      ]
+    },
+    "NCT03713632": {
+      "identifier": "NCT03713632",
+      "briefTitle": "Study of Efficacy and Safety of Two Secukinumab Dose Regimens in Subjects With Moderate to Severe Hidradenitis Suppurativa (HS)",
+      "officialTitle": "A Randomized, Double-blind, Multicenter Study Assessing Short (16 Weeks) and Long-term Efficacy (up to 1 Year), Safety, and Tolerability of 2 Subcutaneous Secukinumab Dose Regimens in Adult Patients With Moderate to Severe Hidradenitis Suppurativa (SUNRISE)",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2024-10-09",
+      "conditions": [
+        "Hidradenitis Suppurativa"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Secukinumab",
+          "description": "Secukinumab 300mg every 2 or every 4 weeks"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Placebo 300mg every 2 or every 4 weeks"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Secukinumab 1",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Secukinumab 300mg every 2 weeks"
+        },
+        {
+          "label": "Secukinumab 2",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Secukinumab 300mg every 4 weeks"
+        },
+        {
+          "label": "Placebo 1",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo group to secukinumab 300mg every 2 weeks"
+        },
+        {
+          "label": "Placebo 2",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo group to secukinumab 300mg every 4 weeks"
+        }
+      ]
+    },
+    "NCT03732807": {
+      "identifier": "NCT03732807",
+      "briefTitle": "PF-06651600 for the Treatment of Alopecia Areata",
+      "officialTitle": "A PHASE 2B/3 RANDOMIZED, DOUBLE-BLIND, PLACEBO-CONTROLLED, DOSE-RANGING STUDY TO INVESTIGATE THE EFFICACY AND SAFETY OF PF-06651600 IN ADULT AND ADOLESCENT ALOPECIA AREATA (AA) SUBJECTS WITH 50% OR GREATER SCALP HAIR LOSS",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2022-02-24",
+      "conditions": [
+        "Alopecia Areata"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "PF-06651600 Induction Dose",
+          "description": "Oral tablets taken once daily (QD)"
+        },
+        {
+          "type": "DRUG",
+          "name": "PF-06651600 Maintenance Dose #1",
+          "description": "Oral tablets taken QD"
+        },
+        {
+          "type": "DRUG",
+          "name": "PF-06651600 Maintenance Dose #2",
+          "description": "Oral tablets taken QD"
+        },
+        {
+          "type": "DRUG",
+          "name": "PF-06651600 Maintenance Dose #3",
+          "description": "Oral tablets taken QD"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Oral tablets taken QD"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Sequence A",
+          "type": "EXPERIMENTAL",
+          "description": "Induction dose given once daily (QD) for 4 weeks followed by maintenance dose #1 given QD for 44 weeks"
+        },
+        {
+          "label": "Sequence B",
+          "type": "EXPERIMENTAL",
+          "description": "Induction dose given QD for 4 weeks followed by maintenance dose #2 given QD for 44 weeks"
+        },
+        {
+          "label": "Sequence C",
+          "type": "EXPERIMENTAL",
+          "description": "Maintenance dose #1 given QD for 48 weeks"
+        },
+        {
+          "label": "Sequence D",
+          "type": "EXPERIMENTAL",
+          "description": "Maintenance dose #2 given QD for 48 weeks"
+        },
+        {
+          "label": "Sequence E",
+          "type": "EXPERIMENTAL",
+          "description": "Maintenance dose #3 given QD for 48 weeks"
+        },
+        {
+          "label": "Sequence F",
+          "type": "EXPERIMENTAL",
+          "description": "Placebo given QD for 24 weeks followed by induction dose given QD for 4 weeks then maintenance dose #1 given QD for 20 weeks"
+        },
+        {
+          "label": "Sequence G",
+          "type": "EXPERIMENTAL",
+          "description": "Placebo given QD for 24 weeks followed by maintenance dose #1 given QD for 24 weeks"
+        }
+      ]
+    },
+    "NCT03762265": {
+      "identifier": "NCT03762265",
+      "briefTitle": "A Study of PRN1008 in Patients With Pemphigus",
+      "officialTitle": "A Randomized, Double-Blind, Placebo-Controlled, Multicenter Trial to Evaluate the Efficacy and Safety of Oral BTK Inhibitor Rilzabrutinib (PRN1008) in Moderate to Severe Pemphigus",
+      "overallStatus": "TERMINATED",
+      "lastUpdatePostDate": "2023-08-02",
+      "conditions": [
+        "Pemphigus"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Rilzabrutinib",
+          "description": "Pharmaceutical form: Tablet Route of administration: Oral"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Pharmaceutical form: Tablet Route of administration: Oral"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Placebo Then Rilzabrutinib",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "In BT period, participants received placebo orally twice daily (BID) up to 37 weeks along with sponsor-provided corticosteroids (CS). After at least two weeks of control of disease activity (CDA; no new lesions and established lesions begin to heal), based on protocol-specified clinical criteria, investigators could decrease the CS dose to a minimum of 5 milligrams (mg) prednisone/prednisolone per day from Week 29 to Week 37. Post completion of BT period, eligible participants received rilzabrutinib 400 mg BID up to Week 61 in OLE period and those who were eligible after OLE period completion, continued the same treatment until Week 109 in LTE period according to protocol-specified criteria."
+        },
+        {
+          "label": "Rilzabrutinib Then Rilzabrutinib",
+          "type": "EXPERIMENTAL",
+          "description": "In BT period, participants received rilzabrutinib 400 mg orally BID up to 37 weeks along with sponsor-provided CS. After at least two weeks of CDA (no new lesions and established lesions begin to heal), based on protocol-specified clinical criteria, investigators could decrease the CS dose to a minimum of 5 mg prednisone/prednisolone per day from Week 29 to Week 37. Post completion of BT period, eligible participants received rilzabrutinib 400 mg BID up to Week 61 in OLE period and those who were eligible after OLE period completion, continued the same treatment until Week 109 in LTE period according to protocol-specified criteria."
+        }
+      ]
+    },
+    "NCT03782792": {
+      "identifier": "NCT03782792",
+      "briefTitle": "Effisayil™ 1: A Study to Test Spesolimab (BI 655130) in Patients With a Flare-up of a Skin Disease Called Generalized Pustular Psoriasis",
+      "officialTitle": "Effisayil™ 1:Multi-center, Double-blind, Randomised, Placebo-controlled, Phase II Study to Evaluate Efficacy, Safety and Tolerability of a Single Intravenous Dose of Spesolimab (BI 655130) in Patients With Generalized Pustular Psoriasis (GPP) Presenting With an Acute Flare of Moderate to Severe Intensity",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2025-10-16",
+      "conditions": [
+        "Generalized Pustular Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Spesolimab",
+          "description": "Solution for infusion"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Solution for infusion"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Spesolimab",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        },
+        {
+          "label": "Placebo",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        }
+      ]
+    },
+    "NCT03813160": {
+      "identifier": "NCT03813160",
+      "briefTitle": "Trial to Evaluate Efficacy and Safety of Lenabasum in Dermatomyositis",
+      "officialTitle": "A Multicenter, Randomized, Double-Blind, Placebo-Controlled Phase 3 Trial to Evaluate Efficacy and Safety of Lenabasum in Dermatomyositis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2022-08-16",
+      "conditions": [
+        "Dermatomyositis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Lenabasum 20 mg",
+          "description": "oral capsule"
+        },
+        {
+          "type": "DRUG",
+          "name": "Lenabasum 5 mg",
+          "description": "oral capsule"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "oral capsule"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Lenabasum 20 mg",
+          "type": "EXPERIMENTAL",
+          "description": "Subjects will receive lenabasum 20 mg twice daily"
+        },
+        {
+          "label": "Lenabasum 5 mg",
+          "type": "EXPERIMENTAL",
+          "description": "Subjects will receive lenabasum 5 mg twice daily"
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Subjects will receive placebo twice daily"
+        }
+      ]
+    },
+    "NCT03895203": {
+      "identifier": "NCT03895203",
+      "briefTitle": "A Study to Test the Efficacy and Safety of Bimekizumab in the Treatment of Subjects With Active Psoriatic Arthritis",
+      "officialTitle": "A Phase 3, Multicenter, Randomized, Double-Blind, Placebo-Controlled, Active Reference (Adalimumab) Study Evaluating the Efficacy and Safety of Bimekizumab in the Treatment of Subjects With Active Psoriatic Arthritis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2026-07-22",
+      "conditions": [
+        "Psoriatic Arthritis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Bimekizumab",
+          "description": "Subjects will receive bimekizumab at pre-specified time-points."
+        },
+        {
+          "type": "DRUG",
+          "name": "Adalimumab",
+          "description": "Adalimumab will be administered according to the labeling recommendations."
+        },
+        {
+          "type": "OTHER",
+          "name": "Placebo",
+          "description": "Subjects will receive placebo at pre-specified time-points."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Bimekzumab dosage regimen",
+          "type": "EXPERIMENTAL",
+          "description": "Subjects randomized to this arm will receive assigned bimekizumab dosage regimen and placebo to maintain the blinding with adalimumab and placebo arms during the Treatment Period."
+        },
+        {
+          "label": "Adalimumab dosage regimen",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Subjects randomized to this arm will receive the assigned adalimumab dosage regimen during the Treatment Period."
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Subjects randomized to this arm will receive placebo during the Double-Blind Treatment Period and will be reallocated to receive bimekizumab dosage regimen during the Maintenance Period."
+        }
+      ]
+    },
+    "NCT03896581": {
+      "identifier": "NCT03896581",
+      "briefTitle": "A Study to Evaluate the Efficacy and Safety of Bimekizumab in the Treatment of Subjects With Active Psoriatic Arthritis",
+      "officialTitle": "A Multicenter, Phase 3, Randomized, Double-Blind, Placebo-Controlled Study Evaluating the Efficacy and Safety of Bimekizumab in the Treatment of Subjects With Active Psoriatic Arthritis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2026-07-22",
+      "conditions": [
+        "Psoriatic Arthritis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Bimekizumab",
+          "description": "Subjects will receive bimekizumab at pre-specified time-points."
+        },
+        {
+          "type": "OTHER",
+          "name": "Placebo",
+          "description": "Subjects will receive placebo at pre-specified time-points."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Bimekizumab dosage regimen",
+          "type": "EXPERIMENTAL",
+          "description": "Subjects randomized to this arm will receive assigned bimekizumab dosage regimen."
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Subjects randomized to this arm will receive placebo."
+        }
+      ]
+    },
+    "NCT03899259": {
+      "identifier": "NCT03899259",
+      "briefTitle": "A Study of Baricitinib (LY3009104) in Adults With Severe or Very Severe Alopecia Areata",
+      "officialTitle": "A Multicenter, Randomized, Double-Blind, Placebo- Controlled, Phase 3 Study to Evaluate the Efficacy and Safety of Baricitinib in Adult Patients With Severe or Very Severe Alopecia Areata",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2026-04-07",
+      "conditions": [
+        "Alopecia Areata"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Baricitinib",
+          "description": "Administered orally"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Administered orally"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants received two placebo tablets matched to baricitinib, administered orally once daily (QD) to maintain the blind."
+        },
+        {
+          "label": "2 mg Baricitinib",
+          "type": "EXPERIMENTAL",
+          "description": "Participants received one 2 mg Baricitinib tablet administered orally QD, and one placebo tablet administered orally QD to maintain the blind."
+        },
+        {
+          "label": "4 mg Baricitinib",
+          "type": "EXPERIMENTAL",
+          "description": "Participants received one 4 mg Baricitinib tablet and one placebo tablet administered orally QD to maintain the blind."
+        },
+        {
+          "label": "Placebo/ Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants who received two placebo tablets administered orally QD in Period 1 continue to receive the same placebo in Period 2."
+        },
+        {
+          "label": "Placebo/ 2-mg Baricitinib",
+          "type": "EXPERIMENTAL",
+          "description": "Participants who received two placebo at Period 1 switched to receive 2 mg Baricitinib dose administered orally QD in Period 2."
+        },
+        {
+          "label": "Placebo/ 4-mg Baricitinib",
+          "type": "EXPERIMENTAL",
+          "description": "Participants who received two placebo at Period 1 switched to receive 4 mg Baricitinib dose administered orally QD in Period 2."
+        },
+        {
+          "label": "2-mg Baricitinib/ 2-mg Baricitinib",
+          "type": "EXPERIMENTAL",
+          "description": "Participants who received 2 mg Baricitinib at Period 1 continued to receive same 2 mg Baricitinib dose administered orally QD in Period 2."
+        },
+        {
+          "label": "2-mg Baricitinib/ 4-mg Baricitinib",
+          "type": "EXPERIMENTAL",
+          "description": "Participants who received 2 mg Baricitinib at Period 1 switched to receive 4 mg Baricitinib dose administered orally QD in Period 2."
+        },
+        {
+          "label": "4-mg Baricitinib/ Placebo",
+          "type": "EXPERIMENTAL",
+          "description": "Participants who received 4 mg Baricitinib at Period 1 switched to receive Placebo administered orally QD in Period 2."
+        },
+        {
+          "label": "4-mg Baricitinib/ 2-mg Baricitinib",
+          "type": "EXPERIMENTAL",
+          "description": "Participants who received 4 mg Baricitinib at Period 1 switched to receive 2 mg Baricitinib administered orally QD in Period 2."
+        },
+        {
+          "label": "4-mg Baricitinib/ 4-mg Baricitinib",
+          "type": "EXPERIMENTAL",
+          "description": "Participants who received 4 mg Baricitinib at Period 1 continued to receive same 4 mg Baricitinib administered orally QD in Period 2."
+        }
+      ]
+    },
+    "NCT03956355": {
+      "identifier": "NCT03956355",
+      "briefTitle": "Tapinarof for the Treatment of Plaque Psoriasis in Adults (3001)",
+      "officialTitle": "A Phase 3 Efficacy and Safety Study of Tapinarof for the Treatment of Plaque Psoriasis in Adults",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2025-06-12",
+      "conditions": [
+        "Plaque Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Tapinarof",
+          "description": "Tapinarof cream, 1%, applied once daily"
+        },
+        {
+          "type": "DRUG",
+          "name": "Vehicle Cream",
+          "description": "Vehicle cream applied once daily"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Tapinarof (DMVT-505)",
+          "type": "EXPERIMENTAL",
+          "description": "Tapinarof (DMVT-505) Cream Group"
+        },
+        {
+          "label": "Vehicle Cream",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Vehicle Cream Group"
+        }
+      ]
+    },
+    "NCT03983980": {
+      "identifier": "NCT03983980",
+      "briefTitle": "Tapinarof for the Treatment of Plaque Psoriasis in Adults (3002)",
+      "officialTitle": "A Phase 3 Efficacy and Safety Study of Tapinarof for the Treatment of Plaque Psoriasis in Adults",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2025-06-12",
+      "conditions": [
+        "Plaque Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Tapinarof",
+          "description": "Tapinarof cream, 1%, applied once daily"
+        },
+        {
+          "type": "DRUG",
+          "name": "Vehicle Cream",
+          "description": "Vehicle cream applied once daily"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Tapinarof (DMVT-505) Cream Group",
+          "type": "EXPERIMENTAL",
+          "description": "Tapinarof cream, 1%, applied once daily"
+        },
+        {
+          "label": "Vehicle Cream Group",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Vehicle cream applied once daily"
+        }
+      ]
+    },
+    "NCT04052425": {
+      "identifier": "NCT04052425",
+      "briefTitle": "Topical Ruxolitinib Evaluation in Vitiligo Study 1 (TRuE-V1)",
+      "officialTitle": "Topical Ruxolitinib Evaluation in Vitiligo Study 1 (TRuE-V1): A Phase 3, Double-Blind, Randomized, Vehicle-Controlled, Efficacy and Safety Study of Ruxolitinib Cream Followed by an Extension Period in Participants With Vitiligo",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2025-08-22",
+      "conditions": [
+        "Non-segmental Vitiligo"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Ruxolitinib cream",
+          "description": "Ruxolitinib cream is a topical formulation applied as a thin film to affected areas."
+        },
+        {
+          "type": "DRUG",
+          "name": "Vehicle",
+          "description": "Vehicle cream is a topical formulation applied as a thin film to affected areas."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Double-Blind Period: Ruxolitinib cream 1.5% BID",
+          "type": "EXPERIMENTAL",
+          "description": "Participants applied ruxolitinib 1.5% cream twice daily (BID) for 24 weeks."
+        },
+        {
+          "label": "Double-Blind Period: Vehicle cream BID",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants applied matching vehicle cream BID for 24 weeks."
+        },
+        {
+          "label": "Treatment-Extension Period: Ruxolitinib cream 1.5% BID",
+          "type": "EXPERIMENTAL",
+          "description": "Participants who completed the Week 24 assessments with no safety concerns could continue into the 28-week Treatment-Extension Period. Participants who applied ruxolitinib cream 1.5% BID during the Double-Blind Period continued to apply ruxolitinib cream 1.5% BID for an additional 28 weeks in the Treatment-Extension Period."
+        },
+        {
+          "label": "Treatment-Extension Period: Vehicle cream to Ruxolitinib cream 1.5% BID",
+          "type": "EXPERIMENTAL",
+          "description": "Participants who completed the Week 24 assessments with no safety concerns could continue into the 28-week Treatment-Extension Period. Participants who applied vehicle cream BID during the Double-Blind Period applied ruxolitinib cream 1.5%m BID for 28 weeks in the Treatment-Extension Period."
+        }
+      ]
+    },
+    "NCT04057573": {
+      "identifier": "NCT04057573",
+      "briefTitle": "Topical Ruxolitinib Evaluation in Vitiligo Study 2 (TRuE-V2)",
+      "officialTitle": "Topical Ruxolitinib Evaluation in Vitiligo Study 2 (TRuE-V2): A Phase 3, Double-Blind, Randomized, Vehicle-Controlled, Efficacy and Safety Study of Ruxolitinib Cream Followed by an Extension Period in Participants With Vitiligo",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2025-08-22",
+      "conditions": [
+        "Non-segmental Vitiligo"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Ruxolitinib cream",
+          "description": "Ruxolitinib cream is a topical formulation applied as a thin film to affected areas."
+        },
+        {
+          "type": "DRUG",
+          "name": "Vehicle",
+          "description": "Vehicle cream is a topical formulation applied as a thin film to affected areas."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Double-Blind Period: Ruxolitinib cream 1.5% BID",
+          "type": "EXPERIMENTAL",
+          "description": "Participants applied ruxolitinib 1.5% cream twice daily (BID) for 24 weeks."
+        },
+        {
+          "label": "Double-Blind Period: Vehicle cream BID",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants applied matching vehicle cream BID for 24 weeks."
+        },
+        {
+          "label": "Treatment-Extension Period: Ruxolitinib cream 1.5% BID",
+          "type": "EXPERIMENTAL",
+          "description": "Participants who completed the Week 24 assessments with no safety concerns could continue into the 28-week Treatment-Extension Period. Participants who applied ruxolitinib cream 1.5% BID during the Double-Blind Period continued to apply ruxolitinib cream 1.5% BID for an additional 28 weeks in the Treatment-Extension Period."
+        },
+        {
+          "label": "Treatment-Extension Period: Vehicle cream to Ruxolitinib cream 1.5% BID",
+          "type": "EXPERIMENTAL",
+          "description": "Participants who completed the Week 24 assessments with no safety concerns could continue into the 28-week Treatment-Extension Period. Participants who applied vehicle cream BID during the Double-Blind Period applied ruxolitinib cream 1.5%m BID for 28 weeks in the Treatment-Extension Period."
+        }
+      ]
+    },
+    "NCT04157348": {
+      "identifier": "NCT04157348",
+      "briefTitle": "Efficacy and Safety of Benralizumab in EGPA Compared to Mepolizumab.",
+      "officialTitle": "A Randomised, Double-blind, Active-controlled 52-week Study With an Open-label Extension to Evaluate the Efficacy and Safety of Benralizumab Compared to Mepolizumab in the Treatment of Eosinophilic Granulomatosis With Polyangiitis (EGPA) in Patients Receiving Standard of Care Therapy (MANDARA Study)",
+      "overallStatus": "ACTIVE_NOT_RECRUITING",
+      "lastUpdatePostDate": "2026-08-12",
+      "conditions": [
+        "Eosinophilic Granulomatous Vasculitis"
+      ],
+      "interventions": [
+        {
+          "type": "BIOLOGICAL",
+          "name": "Benralizumab",
+          "description": "30 mg/mL solution for injection in a single accessorized prefilled syringe (APFS) will be administered subcutaneously (SC)"
+        },
+        {
+          "type": "BIOLOGICAL",
+          "name": "Mepolizumab",
+          "description": "3x100 mg vials of powder for solution for injection reconstituted into 3 separate 1 mL syringes for administration on each dosing occasion. Injection volume per syringe is 1 mL. Mepolizumab active solution will be administered subcutaneously (SC)"
+        },
+        {
+          "type": "BIOLOGICAL",
+          "name": "Placebo to Mepolizumab",
+          "description": "Matching placebo: 0.9% sodium chloride, solutions for injection in 1mL syringes (3 syringes will be used on each dosing occasion). Injection volume per syringe is 1mL. Placebo to Mepolizumban will be administered subcutaneously (SC)"
+        },
+        {
+          "type": "BIOLOGICAL",
+          "name": "Placebo to Benralizumab",
+          "description": "Matching placebo solution for injection in APFS, 1 mL fill volume. Placebo solution will be administered subcutaneously (SC)"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Benralizumab arm",
+          "type": "EXPERIMENTAL",
+          "description": "1x benralizumab SC injection + 3x placebo to mepolizumab SC injections"
+        },
+        {
+          "label": "Mepolizumab arm",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "3x mepolizumab SC injections + 1x placebo to benralizumab SC injection"
+        }
+      ]
+    },
+    "NCT04180488": {
+      "identifier": "NCT04180488",
+      "briefTitle": "Dupilumab for the Treatment of Chronic Spontaneous Urticaria in Patients Who Remain Symptomatic Despite the Use of H1 Antihistamine and Who Are naïve to, Intolerant of, or Incomplete Responders to Omalizumab (LIBERTY-CSU CUPID)",
+      "officialTitle": "Master Protocol of Three Randomized, Double-blind, Placebo Controlled, Multi-center, Parallel-group Studies of Dupilumab in Patients With Chronic Spontaneous Urticaria (CSU) Who Remain Symptomatic Despite the Use of H1 Antihistamine Treatment in Patients naïve to Omalizumab and in Patients Who Are Intolerant or Incomplete Responders to Omalizumab",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2025-08-20",
+      "conditions": [
+        "Chronic Spontaneous Urticaria"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Dupilumab SAR231893",
+          "description": "Pharmaceutical form:Injection solution Route of administration: Subcutaneous"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Pharmaceutical form:Injection solution Route of administration: Subcutaneous"
+        },
+        {
+          "type": "DRUG",
+          "name": "non sedating H1-antihistamine",
+          "description": "Pharmaceutical form:Tablet Route of administration: oral administration"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Study A Dupilumab",
+          "type": "EXPERIMENTAL",
+          "description": "Participants who were omalizumab naïve received dupilumab for 24 weeks as follows: * 300 milligrams (mg) SC injection every 2 weeks (q2w) for adults and those adolescents who weighed \\>=60 kilograms (kg) at screening starting from Week 2 following a loading dose of 600 mg (2×300 mg injections) on Day 1, * 200 mg SC injection q2w for adolescents who weighed \\<60 kg and children (\\>=6 to \\<12 years of age) who weighed \\>=30 kg at screening starting from Week 2 following a loading dose of 400 mg (2×200 mg injections) on Day 1 and * 300 mg SC injection every 4 weeks (q4w) for children (\\>=6 to \\<12 years of age) who weighed \\<30 kg and \\>=15 kg at screening starting from Week 4 following a loading dose of 600 mg (2×300 mg injections) on Day 1."
+        },
+        {
+          "label": "Study A Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants who were omalizumab naïve received placebo matched to dupilumab as subcutaneous (SC) injection including loading dose from Day 1 up to 24 weeks."
+        },
+        {
+          "label": "Study B Dupilumab",
+          "type": "EXPERIMENTAL",
+          "description": "Participants who were intolerant or incomplete responders to omalizumab received dupilumab for 24 weeks as follows: * 300 mg SC injection q2w for adults and those adolescents weighing \\>=60 kg at screening starting from Week 2 following a loading dose of 600 mg (2×300 mg injections) on Day 1 or * 200 mg SC injection q2w for adolescents weighing \\<60 kg at screening starting from Week 2 following a loading dose of 400 mg (2×200 mg injections) on Day 1."
+        },
+        {
+          "label": "Study B Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants who were intolerant or incomplete responders to omalizumab received placebo matched to dupilumab as SC injection including loading dose from Day 1 up to 24 weeks."
+        },
+        {
+          "label": "Study C Dupilumab",
+          "type": "EXPERIMENTAL",
+          "description": "Participants who were omalizumab naïve received dupilumab for 24 weeks as follows: * 300 mg SC injection q2w for adults and those adolescents who weighed \\>=60 kg at screening starting from Week 2 following a loading dose of 600 mg (2×300 mg injections) on Day 1, * 200 mg SC injection q2w for adolescents who weighed \\<60 kg and children (\\>=6 to \\<12 years of age) who weighed \\>=30 kg at screening starting from Week 2 following a loading dose of 400 mg (2×200 mg injections) on Day 1 and * 300 mg SC injection q4w for children (\\>=6 to \\<12 years of age) who weighed \\<30 kg and \\>=15 kg at screening starting from Week 4 following a loading dose of 600 mg (2×300 mg injections) on Day 1."
+        },
+        {
+          "label": "Study C Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants who were omalizumab naïve received placebo matched to dupilumab as SC injection including loading dose from Day 1 up to 24 weeks."
+        }
+      ]
+    },
+    "NCT04206553": {
+      "identifier": "NCT04206553",
+      "briefTitle": "A Study to Evaluate the Efficacy and Safety of Dupilumab in Adult Patients With Bullous Pemphigoid",
+      "officialTitle": "A Multicenter, Randomized, Double-Blind, Placebo-Controlled, Parallel Group Study to Evaluate the Efficacy and Safety of Dupilumab in Adult Patients With Bullous Pemphigoid",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2026-06-18",
+      "conditions": [
+        "Bullous Pemphigoid"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "dupilumab",
+          "description": "Loading dose administered subcutaneous (SC), followed by SC once every 2 weeks (Q2W) dosing."
+        },
+        {
+          "type": "DRUG",
+          "name": "Matching Placebo",
+          "description": "Matching dupilumab without active substance"
+        },
+        {
+          "type": "DRUG",
+          "name": "Oral corticosteroids (OCS)",
+          "description": "Prednisone or prednisolone per standard of care to obtain control of disease activity."
+        }
+      ],
+      "arms": [
+        {
+          "label": "dupilumab",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        },
+        {
+          "label": "Matching placebo",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        }
+      ]
+    },
+    "NCT04211363": {
+      "identifier": "NCT04211363",
+      "briefTitle": "Trial of PDE4 Inhibition With Roflumilast for the Management of Plaque Psoriasis",
+      "officialTitle": "A Phase 3, 8-Week, Parallel Group, Double Blind, Vehicle-Controlled Study of the Safety and Efficacy of ARQ-151 Cream 0.3% Administered QD in Subjects With Chronic Plaque Psoriasis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2022-12-07",
+      "conditions": [
+        "Chronic Plaque Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Roflumilast 0.3% cream",
+          "description": "Roflumilast 0.3% cream for topical application."
+        },
+        {
+          "type": "DRUG",
+          "name": "Vehicle Cream",
+          "description": "Vehicle cream for topical application."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Rofumilast Cream 0.3%",
+          "type": "EXPERIMENTAL",
+          "description": "Participants receive roflumilast cream 0.3% once daily for 8 weeks."
+        },
+        {
+          "label": "Vehicle cream",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants receive vehicle cream once daily for 8 weeks."
+        }
+      ]
+    },
+    "NCT04211389": {
+      "identifier": "NCT04211389",
+      "briefTitle": "Twin Trial of PDE4 Inhibition With Roflumilast for the Management of Plaque Psoriasis",
+      "officialTitle": "A Phase 3, 8-Week, Parallel Group, Double Blind, Vehicle-Controlled Study of the Safety and Efficacy of ARQ-151 Cream 0.3% Administered QD in Subjects With Chronic Plaque Psoriasis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2022-12-07",
+      "conditions": [
+        "Chronic Plaque Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "ARQ-151 0.3% cream",
+          "description": "ARQ-151 0.3% cream"
+        },
+        {
+          "type": "DRUG",
+          "name": "ARQ-151 vehicle cream",
+          "description": "ARQ-151 vehicle cream"
+        }
+      ],
+      "arms": [
+        {
+          "label": "ARQ-151 cream 0.3%",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Active comparator"
+        },
+        {
+          "label": "ARQ-151 cream vehicle",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo comparator"
+        }
+      ]
+    },
+    "NCT04242446": {
+      "identifier": "NCT04242446",
+      "briefTitle": "A Study to Evaluate the Efficacy and Safety of Bimekizumab in Study Participants With Moderate to Severe Hidradenitis Suppurativa",
+      "officialTitle": "A Phase 3, Randomized, Double-Blind, Placebo-Controlled, Multicenter Study Evaluating the Efficacy and Safety of Bimekizumab in Study Participants With Moderate to Severe Hidradenitis Suppurativa",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2026-05-19",
+      "conditions": [
+        "Hidradenitis Suppurativa"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Bimekizumab",
+          "description": "Subjects will receive bimekizumab at pre-specified time-points."
+        },
+        {
+          "type": "OTHER",
+          "name": "Placebo",
+          "description": "Subjects will receive placebo at pre-specified time-points during the Initial Treatment Period."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Bimekizumab dosing regimen 1",
+          "type": "EXPERIMENTAL",
+          "description": "Subjects participating in the study will receive assigned bimekizumab dosing regimen 1 during the Treatment Period."
+        },
+        {
+          "label": "Bimekizumab dosing regimen 2",
+          "type": "EXPERIMENTAL",
+          "description": "Subjects participating in the study will receive assigned bimekizumab dosing regimen 2 during the Treatment Period."
+        },
+        {
+          "label": "Bimekizumab dosing regimen 3",
+          "type": "EXPERIMENTAL",
+          "description": "Subjects participating in the study will receive assigned bimekizumab dosing regimen 3 during the Treatment Period."
+        },
+        {
+          "label": "Placebo Group",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Subjects randomized to this arm will receive placebo during the Initial Treatment Period and bimekizumab during the Maintenance Treatment Period."
+        }
+      ]
+    },
+    "NCT04242498": {
+      "identifier": "NCT04242498",
+      "briefTitle": "A Study to Evaluate the Efficacy and Safety of Bimekizumab in Study Participants With Moderate to Severe Hidradenitis Suppurativa",
+      "officialTitle": "A Phase 3, Randomized, Double-Blind, Placebo-Controlled, Multicenter Study Evaluating the Efficacy and Safety of Bimekizumab in Study Participants With Moderate to Severe Hidradenitis Suppurativa",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2026-05-19",
+      "conditions": [
+        "Hidradenitis Suppurativa"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Bimekizumab",
+          "description": "Subjects will receive bimekizumab at pre-specified time-points."
+        },
+        {
+          "type": "OTHER",
+          "name": "Placebo",
+          "description": "Subjects will receive placebo at pre-specified time-points during the Initial Treatment Period."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Bimekizumab dosing regimen 1",
+          "type": "EXPERIMENTAL",
+          "description": "Subjects participating in the study will receive assigned bimekizumab dosing regimen 1 during the Treatment Period."
+        },
+        {
+          "label": "Bimekizumab dosing regimen 2",
+          "type": "EXPERIMENTAL",
+          "description": "Subjects participating in the study will receive assigned bimekizumab dosing regimen 2 during the Treatment Period."
+        },
+        {
+          "label": "Bimekizumab dosing regimen 3",
+          "type": "EXPERIMENTAL",
+          "description": "Subjects participating in the study will receive assigned bimekizumab dosing regimen 3 during the Treatment Period."
+        },
+        {
+          "label": "Placebo Group",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Subjects randomized to this arm will receive placebo during the Initial Treatment Period and bimekizumab during the Maintenance Treatment Period."
+        }
+      ]
+    },
+    "NCT04274257": {
+      "identifier": "NCT04274257",
+      "briefTitle": "A Study of the Efficacy and Safety of Rituximab in Participants With Systemic Sclerosis",
+      "officialTitle": "Double-Blind, Parallel-group Comparison, Investigators Initiated Phase II Clinical Trial of IDEC-C2B8 (Rituximab) in Patients With Systemic Sclerosis",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2020-02-18",
+      "conditions": [
+        "Scleroderma, Systemic",
+        "Skin Sclerosis",
+        "Lung Fibrosis",
+        "Autoimmune Diseases",
+        "Collagen Diseases"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Double-Blind Placebo",
+          "description": "The 4-week treatment period (four 375 mg/m2 doses at 1-week intervals) and subsequent 20-week follow-up period constitute one cycle of treatment. In the double-blind period, one cycle of placebo will be administered. In the active drug period, one additional cycle (rituximab) will be administered."
+        },
+        {
+          "type": "DRUG",
+          "name": "Double-Blind Rituximab",
+          "description": "The 4-week treatment period (four 375 mg/m2 doses at 1-week intervals) and subsequent 20-week follow-up period constitute one cycle of treatment. In the double-blind period, one cycle of rituximab will be administered. In the active drug period, one additional cycle (rituximab) will be administered."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Double-Blind Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants will receive double-blind matching placebo from baseline until week 24. Participants may then receive open-label rituximab from weeks 24 to 48."
+        },
+        {
+          "label": "Double-Blind Rituximab",
+          "type": "EXPERIMENTAL",
+          "description": "Participants will receive double-blind rituximab from baseline until week 24. Participants may then receive open-label rituximab from weeks 24 to 48."
+        }
+      ]
+    },
+    "NCT04399837": {
+      "identifier": "NCT04399837",
+      "briefTitle": "A Study to Test Whether BI 655130 (Spesolimab) Prevents Flare-ups in Patients With Generalized Pustular Psoriasis",
+      "officialTitle": "Effisayil™ 2: Multi-center, Randomized, Parallel Group, Double Blind, Placebo Controlled, Phase IIb Dose-finding Study to Evaluate Efficacy and Safety of BI 655130 (Spesolimab) Compared to Placebo in Preventing Generalized Pustular Psoriasis (GPP) Flares in Patients With History of GPP.",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2025-10-20",
+      "conditions": [
+        "Generalized Pustular Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Spesolimab",
+          "description": "Solution for injection"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Solution for injection"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Spesolimab SC low dose",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        },
+        {
+          "label": "Spesolimab SC medium dose",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        },
+        {
+          "label": "Spesolimab SC high dose",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": ""
+        }
+      ]
+    },
+    "NCT04422912": {
+      "identifier": "NCT04422912",
+      "briefTitle": "A Phase 1/2, Open-label, Safety and Dosing Study of Autologous CART Cells (Desmoglein 3 Chimeric Autoantibody Receptor T Cells [DSG3-CAART] or CD19-specific Chimeric Antigen Receptor T Cells [CABA-201]) in Subjects With Active, Pemphigus Vulgaris (RESET-PV)",
+      "officialTitle": "A Phase 1/2, Open-label, Safety and Dosing Study of Autologous CART Cells (Desmoglein 3 Chimeric Autoantibody Receptor T Cells [DSG3-CAART] or CD19-specific Chimeric Antigen Receptor T Cells [CABA-201]) in Subjects With Active, Pemphigus Vulgaris",
+      "overallStatus": "RECRUITING",
+      "lastUpdatePostDate": "2026-05-29",
+      "conditions": [
+        "Pemphigus Vulgaris"
+      ],
+      "interventions": [
+        {
+          "type": "BIOLOGICAL",
+          "name": "DSG3-CAART",
+          "description": "Intravenous infusions of DSG3-CAART alone at different doses and different fractionations, with or without intravenous immunoglobulin, cyclophosphamide, and/or fludarabine."
+        },
+        {
+          "type": "BIOLOGICAL",
+          "name": "CABA-201",
+          "description": "Single intravenous infusion of CABA-201 at escalating doses, with or without preconditioning."
+        }
+      ],
+      "arms": [
+        {
+          "label": "DSG3-CAART",
+          "type": "EXPERIMENTAL",
+          "description": "Single or multiple intravenous infusion(s) of DSG3-CAART at varying dose levels. This study is now closed to enrollment."
+        },
+        {
+          "label": "CABA-201",
+          "type": "EXPERIMENTAL",
+          "description": "Infusion of CABA-201 with or without cyclophosphamide and fludarabine preconditioning, or with or without cyclophosphamide preconditioning. This sub-study is open to enrollment."
+        }
+      ]
+    },
+    "NCT04518995": {
+      "identifier": "NCT04518995",
+      "briefTitle": "Study to Evaluate the Efficacy and Safety of CTP-543 in Adults With Moderate to Severe Alopecia Areata (THRIVE-AA1)",
+      "officialTitle": "A Double-Blind, Randomized, Placebo-Controlled Study to Evaluate the Efficacy and Safety of CTP-543 in Adult Patients With Moderate to Severe Alopecia Areata (THRIVE-AA1)",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2023-05-03",
+      "conditions": [
+        "Alopecia Areata"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "CTP-543 matching placebo",
+          "description": "Administered as tablets."
+        },
+        {
+          "type": "DRUG",
+          "name": "CTP-543",
+          "description": "Administered as tablets."
+        },
+        {
+          "type": "DRUG",
+          "name": "CTP-543",
+          "description": "Administered as tablets."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Placebo",
+          "type": "EXPERIMENTAL",
+          "description": "Participants received CTP-543 matched placebo tablets, orally, twice daily (BID) for up to 24 weeks."
+        },
+        {
+          "label": "CTP-543 8 mg BID",
+          "type": "EXPERIMENTAL",
+          "description": "Participants received CTP-543 8 mg tablets, orally, BID for up to 24 weeks."
+        },
+        {
+          "label": "CTP-543 12 mg BID",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants received CTP-543 12 mg tablets, orally, BID for up to 24 weeks."
+        }
+      ]
+    },
+    "NCT04598451": {
+      "identifier": "NCT04598451",
+      "briefTitle": "A Study to Assess the Efficacy and Safety of a Subcutaneous Formulation of Efgartigimod PH20 SC in Adults With Pemphigus (Vulgaris or Foliaceus)",
+      "officialTitle": "A Randomized, Double-Blinded, Placebo-Controlled Trial to Investigate the Efficacy, Safety, and Tolerability of Efgartigimod PH20 SC in Adult Patients With Pemphigus (Vulgaris or Foliaceus)",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2024-10-01",
+      "conditions": [
+        "Pemphigus Vulgaris",
+        "Pemphigus Foliaceus"
+      ],
+      "interventions": [
+        {
+          "type": "BIOLOGICAL",
+          "name": "efgartigimod PH20 SC",
+          "description": "Subcutaneous injection of efgartigimod using rHuPH20 (PH20) as a permeation enhancer"
+        },
+        {
+          "type": "OTHER",
+          "name": "Placebo",
+          "description": "Subcutaneous injection of placebo"
+        },
+        {
+          "type": "DRUG",
+          "name": "prednisone",
+          "description": "Oral prednisone tablets"
+        }
+      ],
+      "arms": [
+        {
+          "label": "efgartigimod PH20 SC",
+          "type": "EXPERIMENTAL",
+          "description": "patients receiving efgartigimod PH20 SC on top of prednisone"
+        },
+        {
+          "label": "placebo",
+          "type": "EXPERIMENTAL",
+          "description": "patients receiving placebo on top of prednisone"
+        }
+      ]
+    },
+    "NCT04797650": {
+      "identifier": "NCT04797650",
+      "briefTitle": "Study to Evaluate the Efficacy and Safety of CTP-543 in Adults With Moderate to Severe Alopecia Areata (THRIVE-AA2)",
+      "officialTitle": "A Double-Blind, Randomized, Placebo-Controlled Study to Evaluate the Efficacy and Safety of CTP-543 in Adult Patients With Moderate to Severe Alopecia Areata",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2023-07-03",
+      "conditions": [
+        "Alopecia Areata"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "CTP-543 matching placebo",
+          "description": "Administered as tablets."
+        },
+        {
+          "type": "DRUG",
+          "name": "CTP-543",
+          "description": "Administered as tablets."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants received CTP-543 matched placebo tablets, orally, twice daily (BID) for up to 24 weeks."
+        },
+        {
+          "label": "CTP-543 8 mg BID",
+          "type": "EXPERIMENTAL",
+          "description": "Participants received CTP-543 8 mg tablets, orally, BID for up to 24 weeks."
+        },
+        {
+          "label": "CTP-543 12 mg BID",
+          "type": "EXPERIMENTAL",
+          "description": "Participants received CTP-543 12 mg tablets, orally, BID for up to 24 weeks."
+        }
+      ]
+    },
+    "NCT04908189": {
+      "identifier": "NCT04908189",
+      "briefTitle": "A Study to Determine the Efficacy and Safety of Deucravacitinib Compared With Placebo in Participants With Active Psoriatic Arthritis (PsA) Who Are Naïve to Biologic Disease Modifying Anti-rheumatic Drugs or Had Previously Received TNFα Inhibitor Treatment",
+      "officialTitle": "A Multi-center, Randomized, Double-blind, Placebo-controlled Phase 3 Study to Evaluate the Efficacy and Safety of Deucravacitinib in Participants With Active Psoriatic Arthritis (PsA) Who Are Naïve to Biologic Disease Modifying Anti-rheumatic Drugs or Had Previously Received TNFα Inhibitor Treatment",
+      "overallStatus": "ACTIVE_NOT_RECRUITING",
+      "lastUpdatePostDate": "2025-06-13",
+      "conditions": [
+        "Psoriatic Arthritis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Deucravacitinib",
+          "description": "Specified dose on specified days"
+        },
+        {
+          "type": "OTHER",
+          "name": "Placebo",
+          "description": "Specified dose on specified days"
+        },
+        {
+          "type": "DRUG",
+          "name": "Apremilast",
+          "description": "Specified dose on specified days"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Deucravacitinib",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": ""
+        },
+        {
+          "label": "Apremilast",
+          "type": "OTHER",
+          "description": ""
+        }
+      ]
+    },
+    "NCT04908202": {
+      "identifier": "NCT04908202",
+      "briefTitle": "A Study to Determine the Efficacy and Safety of Deucravacitinib Compared With Placebo in Participants With Active Psoriatic Arthritis (PsA) Who Are Naïve to Biologic Disease-modifying Anti-rheumatic Drugs",
+      "officialTitle": "A Phase 3, Randomized, Double-blind, Placebo-controlled Study to Evaluate the Efficacy and Safety of Deucravacitinib in Participants With Active Psoriatic Arthritis Who Are Naïve to Biologic Disease-modifying Anti-rheumatic Drugs",
+      "overallStatus": "ACTIVE_NOT_RECRUITING",
+      "lastUpdatePostDate": "2026-04-23",
+      "conditions": [
+        "Psoriatic Arthritis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Deucravacitinib",
+          "description": "Specified dose on specified days"
+        },
+        {
+          "type": "OTHER",
+          "name": "Placebo",
+          "description": "Specified dose on specified days"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Deucravacitinib",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": ""
+        }
+      ]
+    },
+    "NCT05198557": {
+      "identifier": "NCT05198557",
+      "briefTitle": "A Study of MT-0551 in Patients With Systemic Sclerosis",
+      "officialTitle": "Phase 3 Study of MT-0551 in Patients With Systemic Sclerosis (Placebo-Controlled Double-Blind Study)",
+      "overallStatus": "ACTIVE_NOT_RECRUITING",
+      "lastUpdatePostDate": "2025-12-08",
+      "conditions": [
+        "Systemic Sclerosis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Inebilizumab",
+          "description": "Participants will receive IV inebilizumab."
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Participants will receive IV placebo matched to inebilizumab."
+        }
+      ],
+      "arms": [
+        {
+          "label": "MT-0551 group",
+          "type": "EXPERIMENTAL",
+          "description": "Participants will receive intravenous (IV) inebilizumab on Day 1 and Day 15 of randomized controlled period (RCP). The participants who entered open label period (OLP) will receive IV inebilizumab on Day 1 and IV placebo on Day 15 of OLP and will be followed by IV inebilizumab every 26 weeks."
+        },
+        {
+          "label": "Placebo group",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants will receive IV placebo on Day 1 and Day 15 of the RCP. The participants who entered OLP will receive IV inebilizumab on both Day 1 and Day 15 in OLP and will be followed by IV inebilizumab every 26 weeks."
+        }
+      ]
+    },
+    "NCT05263934": {
+      "identifier": "NCT05263934",
+      "briefTitle": "Efficacy and Safety of Depemokimab Compared With Mepolizumab in Adults With Relapsing or Refractory Eosinophilic Granulomatosis With Polyangiitis (EGPA)",
+      "officialTitle": "A 52-week, Randomized, Double-blind, Double-dummy, Parallel-group, Multi-centre, Non-inferiority Study to Investigate the Efficacy and Safety of Depemokimab Compared With Mepolizumab in Adults With Relapsing or Refractory Eosinophilic Granulomatosis With Polyangiitis (EGPA) Receiving Standard of Care (SoC) Therapy",
+      "overallStatus": "ACTIVE_NOT_RECRUITING",
+      "lastUpdatePostDate": "2026-07-08",
+      "conditions": [
+        "Eosinophilic Granulomatosis With Polyangiitis"
+      ],
+      "interventions": [
+        {
+          "type": "BIOLOGICAL",
+          "name": "Depemokimab",
+          "description": "Depemokimab will be administered"
+        },
+        {
+          "type": "BIOLOGICAL",
+          "name": "Mepolizumab",
+          "description": "Mepolizumab will be administered"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo matching mepolizumab",
+          "description": "Placebo matching to mepolizumab will be administered."
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo matching depemokimab",
+          "description": "Placebo matching to depemokimab will be administered."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Participants receiving depemokimab+placebo matching mepolizumab",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        },
+        {
+          "label": "Participants receiving mepolizumab+placebo matching depemokimab",
+          "type": "ACTIVE_COMPARATOR",
+          "description": ""
+        }
+      ]
+    },
+    "NCT05267600": {
+      "identifier": "NCT05267600",
+      "briefTitle": "A Phase 2/3 Study of Efgartigimod PH20 SC in Adult Participants With Bullous Pemphigoid",
+      "officialTitle": "A Phase 2/3, Randomized, Double-Blinded, Placebo-Controlled, Parallel-Group Study to Investigate the Efficacy and Safety of Efgartigimod PH20 SC in Adult Participants With Bullous Pemphigoid",
+      "overallStatus": "COMPLETED",
+      "lastUpdatePostDate": "2025-10-23",
+      "conditions": [
+        "Bullous Pemphigoid"
+      ],
+      "interventions": [
+        {
+          "type": "BIOLOGICAL",
+          "name": "efgartigimod PH20 SC",
+          "description": "Subcutaneous injection of efgartigimod coformulated with rHuPH20, a permeation enhancer"
+        },
+        {
+          "type": "OTHER",
+          "name": "placebo",
+          "description": "Subcutaneous injection of placebo coformulated with rHuPH20, a permeation enhancer"
+        },
+        {
+          "type": "DRUG",
+          "name": "Prednisone",
+          "description": "Oral Prednisone"
+        }
+      ],
+      "arms": [
+        {
+          "label": "efgartigimod PH20 SC",
+          "type": "EXPERIMENTAL",
+          "description": "participants receiving efgartigimod PH20 SC on top of Prednisone"
+        },
+        {
+          "label": "placebo PH20 SC",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "participants receiving placebo PH20 SC on top of Prednisone"
+        }
+      ]
+    },
+    "NCT05437263": {
+      "identifier": "NCT05437263",
+      "briefTitle": "A Study to Investigate the Efficacy and Safety of Brepocitinib in Adults With Dermatomyositis",
+      "officialTitle": "A Phase 3, Randomized, Double-Blind, Placebo-Controlled Study to Investigate the Efficacy and Safety of Oral Brepocitinib in Adults With Dermatomyositis",
+      "overallStatus": "ACTIVE_NOT_RECRUITING",
+      "lastUpdatePostDate": "2026-07-17",
+      "conditions": [
+        "Dermatomyositis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Brepocitinib",
+          "description": "Oral Brepocitinib"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Oral Placebo"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Brepocitinib Dose Level 1 PO QD",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        },
+        {
+          "label": "Brepocitinib Dose Level 2 PO QD",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        },
+        {
+          "label": "Placebo PO QD",
+          "type": "PLACEBO_COMPARATOR",
+          "description": ""
+        }
+      ]
+    },
+    "NCT05531565": {
+      "identifier": "NCT05531565",
+      "briefTitle": "A 2-Part Study to Learn Whether Litifilimab (BIIB059) Injections Can Improve Symptoms of Adult Participants Who Have Active Cutaneous Lupus Erythematosus",
+      "officialTitle": "A 2-Part Seamless Part A (Phase 2)/Part B (Phase 3) Randomized, Double-Blind, Placebo-Controlled, Multicenter Study to Evaluate the Efficacy and Safety of BIIB059 in Participants With Active Subacute Cutaneous Lupus Erythematosus and/or Chronic Cutaneous Lupus Erythematosus With or Without Systemic Manifestations and Refractory and/or Intolerant to Antimalarial Therapy (AMETHYST)",
+      "overallStatus": "ACTIVE_NOT_RECRUITING",
+      "lastUpdatePostDate": "2026-07-31",
+      "conditions": [
+        "Subacute Cutaneous Lupus Erythematosus",
+        "Chronic Cutaneous Lupus Erythematosus"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Litifilimab",
+          "description": "Administered as specified in the treatment arm."
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Administered as specified in the treatment arm."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Part A (Phase 2): Litifilimab",
+          "type": "EXPERIMENTAL",
+          "description": "Participants will receive litifilimab subcutaneously (SC) once every 4 weeks (Q4W) from Week 0 to Week 20, with an additional dose of litifilimab at Week 2 during the double-blind placebo-controlled (DBPC) treatment period. Following the DBPC treatment period, participants will receive litifilimab during the extended treatment period (ETP) from Week 24 to Week 48, with an additional dose of litifilimab-matching placebo at Week 26."
+        },
+        {
+          "label": "Part A (Phase 2): Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants will receive litifilimab-matching placebo SC Q4W from Week 0 to Week 20, with an additional dose of litifilimab-matching placebo at Week 2 during the DBPC treatment period. Following the DBPC treatment period, participants will receive litifilimab during the ETP from Week 24 to Week 48, with an additional dose of litifilimab at Week 26."
+        },
+        {
+          "label": "Part B (Phase 3): Litifilimab",
+          "type": "EXPERIMENTAL",
+          "description": "Participants will receive litifilimab SC Q4W from Week 0 to Week 20, with an additional dose of litifilimab at Week 2 during the DBPC treatment period. Following the DBPC treatment period, participants will receive litifilimab during the ETP from Week 24 to Week 48, with an additional dose of litifilimab-matching placebo at Week 26."
+        },
+        {
+          "label": "Part B (Phase 3): Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants will receive litifilimab-matching placebo SC Q4W from Week 0 to Week 20, with an additional dose of litifilimab-matching placebo at Week 2 during the DBPC treatment period. Following the DBPC treatment period, participants will receive litifilimab during the ETP from Week 24 to Week 48, with an additional dose of litifilimab at Week 26."
+        }
+      ]
+    },
+    "NCT05681481": {
+      "identifier": "NCT05681481",
+      "briefTitle": "A Phase 3 Study to Evaluate the Long-term Safety, Tolerability and Efficacy of Efgartigimod PH20 SC in Adult Participants With Bullous Pemphigoid",
+      "officialTitle": "An Open-label Extension Study of ARGX-113-2009 to Evaluate the Long Term Safety, Tolerability, and Efficacy of Efgartigimod PH20 SC in Adult Participants With Bullous Pemphigoid",
+      "overallStatus": "TERMINATED",
+      "lastUpdatePostDate": "2026-02-25",
+      "conditions": [
+        "Bullous Pemphigoid"
+      ],
+      "interventions": [
+        {
+          "type": "BIOLOGICAL",
+          "name": "efgartigimod PH20 SC",
+          "description": "Subcutaneous injection of efgartigimod coformulated with rHuPH20, a permeation enhancer"
+        },
+        {
+          "type": "DRUG",
+          "name": "Prednisone",
+          "description": "Oral Prednisone"
+        }
+      ],
+      "arms": [
+        {
+          "label": "efgartigimod PH20 SC",
+          "type": "EXPERIMENTAL",
+          "description": "participants receiving efgartigimod PH20 SC on top of Prednisone"
+        }
+      ]
+    },
+    "NCT05925803": {
+      "identifier": "NCT05925803",
+      "briefTitle": "Determine Effectiveness of Anifrolumab In SYstemic Sclerosis (DAISY)",
+      "officialTitle": "A Multicenter, Randomized, Parallel-group, Double-blind,Two-arm Phase III Study to Evaluate the Safety and Efficacy of Anifrolumab Compared With Placebo in Male and Female Participants 18 to 70 Years of Age Inclusive With Systemic Sclerosis",
+      "overallStatus": "ACTIVE_NOT_RECRUITING",
+      "lastUpdatePostDate": "2026-07-23",
+      "conditions": [
+        "Systemic Sclerosis",
+        "Scleroderma"
+      ],
+      "interventions": [
+        {
+          "type": "COMBINATION_PRODUCT",
+          "name": "Anifrolumab (blinded)",
+          "description": "Anifrolumab treatment delivered subcutaneously, once weekly for 52 weeks"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo (blinded)",
+          "description": "matched placebo delivered subcutaneously, once weekly for 52 weeks"
+        },
+        {
+          "type": "COMBINATION_PRODUCT",
+          "name": "Anifrolumab (unblinded, open label)",
+          "description": "At Week 52, all patients will receive Anifrolumab subcutaneously once weekly for 52 weeks"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Anifrolumab (subcutaneous weekly injection)",
+          "type": "EXPERIMENTAL",
+          "description": "Anifrolumab subcutaneous injection once weekly"
+        },
+        {
+          "label": "matched placebo control (subcutaneous weekly injection)",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "matched placebo control subcutaneous injection once weekly"
+        }
+      ]
+    },
+    "NCT06095115": {
+      "identifier": "NCT06095115",
+      "briefTitle": "A Study of JNJ-77242113 in Adolescent and Adult Participants With Moderate to Severe Plaque Psoriasis",
+      "officialTitle": "A Phase 3 Multicenter, Randomized, Double-blind, Placebo-controlled Study to Evaluate the Efficacy and Safety of JNJ-77242113 for the Treatment of Participants With Moderate to Severe Plaque Psoriasis With Randomized Withdrawal and Retreatment",
+      "overallStatus": "ACTIVE_NOT_RECRUITING",
+      "lastUpdatePostDate": "2026-07-06",
+      "conditions": [
+        "Plaque Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "JNJ-77242113",
+          "description": "JNJ-77242113 will be administered orally."
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Placebo will be administered orally"
+        }
+      ],
+      "arms": [
+        {
+          "label": "JNJ-77242113",
+          "type": "EXPERIMENTAL",
+          "description": "Adolescent and adult participants will receive JNJ-77242113 from Week 0 through Week 156. At Week 24, adult participants who are psoriasis area and severity index (PASI) 75 or investigator global assessment (IGA) score of 0 or 1 responders (that is, those who achieve an IGA score of 0 or 1 and have \\>=2-grade improvement from baseline) will be re-randomized either to continue JNJ-77242113 or to placebo (and will be retreated with JNJ-77242113 upon loss of \\>=50% of their Week 24 PASI improvement). Adult participants identified as both PASI 75 and IGA 0 or 1 score non-responders will continue to receive JNJ-77242113 through Week 52. From Week 52 to Week 156, all adult participants will receive JNJ-77242113. Adolescents will not participate in re-randomization regardless of their PASI score or IGA score at Week 24. Adolescents will continue to receive JNJ-77242113 from Week 0 through Week 156."
+        },
+        {
+          "label": "Placebo",
+          "type": "EXPERIMENTAL",
+          "description": "Adolescent and adult participants will receive JNJ-77242113 matching placebo from Week 0 to Week 16. Participants will cross-over to receive JNJ-77242113 from Week 16 through Week 156."
+        }
+      ]
+    },
+    "NCT06143878": {
+      "identifier": "NCT06143878",
+      "briefTitle": "A Study of JNJ-77242113 for the Treatment of Participants With Moderate to Severe Plaque Psoriasis",
+      "officialTitle": "A Phase 3 Multicenter, Randomized, Double-blind, Placebo-controlled and Deucravacitinib Active Comparator-controlled Study to Evaluate the Efficacy and Safety of JNJ-77242113 for the Treatment of Participants With Moderate to Severe Plaque Psoriasis",
+      "overallStatus": "ACTIVE_NOT_RECRUITING",
+      "lastUpdatePostDate": "2026-07-07",
+      "conditions": [
+        "Plaque Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "JNJ-77242113",
+          "description": "JNJ-77242113 will be administered orally."
+        },
+        {
+          "type": "DRUG",
+          "name": "JNJ-77242113 Matching Placebo",
+          "description": "JNJ-77242113 matching placebo will be administered orally."
+        },
+        {
+          "type": "DRUG",
+          "name": "Deucravacitinib",
+          "description": "Deucravacitinib will be administered orally."
+        },
+        {
+          "type": "DRUG",
+          "name": "Deucravacitinib Matching Placebo",
+          "description": "Deucravacitinib matching placebo will be administered orally."
+        }
+      ],
+      "arms": [
+        {
+          "label": "JNJ-77242113",
+          "type": "EXPERIMENTAL",
+          "description": "Participants will receive JNJ-77242113 from Week 0 through Week 156 and deucravacitinib matching placebo from Week 0 through Week 24."
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants will receive matching placebo for JNJ-77242113 from Week 0 through Week 16, matching placebo for deucravacitinib from Week 0 through Week 24 and JNJ-77242113 from Week 16 through Week 156."
+        },
+        {
+          "label": "Deucravacitinib",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Participants will receive deucravacitinib from Week 0 through Week 24 and matching placebo for JNJ-77242113 from Week 0 through Week 24 and JNJ-77242113 from Week 24 through Week 156."
+        }
+      ]
+    },
+    "NCT06220604": {
+      "identifier": "NCT06220604",
+      "briefTitle": "A Study of JNJ-77242113 for the Treatment of Participants With Moderate to Severe Plaque Psoriasis (ICONIC-ADVANCE 2)",
+      "officialTitle": "A Phase 3 Multicenter, Randomized, Double-blind, Placebo-controlled and Deucravacitinib Active Comparator-controlled Study to Evaluate the Efficacy and Safety of JNJ-77242113 for the Treatment of Participants With Moderate to Severe Plaque Psoriasis",
+      "overallStatus": "ACTIVE_NOT_RECRUITING",
+      "lastUpdatePostDate": "2026-07-07",
+      "conditions": [
+        "Plaque Psoriasis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "JNJ-77242113",
+          "description": "JNJ-77242113 will be administered orally."
+        },
+        {
+          "type": "DRUG",
+          "name": "JNJ-77242113 Matching Placebo",
+          "description": "JNJ-77242113 matching placebo will be administered orally."
+        },
+        {
+          "type": "DRUG",
+          "name": "Deucravacitinib",
+          "description": "Deucravacitinib will be administered orally."
+        },
+        {
+          "type": "DRUG",
+          "name": "Deucravacitinib Matching Placebo",
+          "description": "Deucravacitinib matching placebo will be administered orally."
+        }
+      ],
+      "arms": [
+        {
+          "label": "JNJ-77242113",
+          "type": "EXPERIMENTAL",
+          "description": "Participants will receive JNJ-77242113 from Week 0 through Week 156 and deucravacitinib matching placebo from Week 0 through Week 24."
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Participants will receive matching placebo for JNJ-77242113 from Week 0 through Week 16, matching placebo for deucravacitinib from Week 0 through Week 24 and JNJ-77242113 from Week 16 through Week 156."
+        },
+        {
+          "label": "Deucravacitinib",
+          "type": "ACTIVE_COMPARATOR",
+          "description": "Participants will receive deucravacitinib from Week 0 through Week 24 and matching placebo for JNJ-77242113 from Week 0 through Week 24 and JNJ-77242113 from Week 24 through Week 156."
+        }
+      ]
+    },
+    "NCT06328777": {
+      "identifier": "NCT06328777",
+      "briefTitle": "RESET-SSc: An Open-Label Study to Evaluate the Safety and Efficacy of CABA-201, a CD19-CAR T Cell Therapy, in Subjects With Systemic Sclerosis",
+      "officialTitle": "A Phase 1/2, Open-Label Study to Evaluate the Safety and Efficacy of Autologous CD19-specific Chimeric Antigen Receptor T Cells (CABA-201) in Subjects With Systemic Sclerosis",
+      "overallStatus": "RECRUITING",
+      "lastUpdatePostDate": "2026-07-22",
+      "conditions": [
+        "Systemic Sclerosis",
+        "Scleroderma"
+      ],
+      "interventions": [
+        {
+          "type": "BIOLOGICAL",
+          "name": "CABA-201",
+          "description": "Single intravenous infusion of CABA-201 at a single dose level following preconditioning with fludarabine and cyclophosphamide"
+        }
+      ],
+      "arms": [
+        {
+          "label": "CABA-201",
+          "type": "EXPERIMENTAL",
+          "description": "Severe Skin Cohort: Infusion of CABA-201 with preconditioning in subjects with SSc with severe skin involvement Organ Cohort: Infusion of CABA-201 with preconditioning in subjects with SSc with organ involvement"
+        }
+      ]
+    },
+    "NCT06470048": {
+      "identifier": "NCT06470048",
+      "briefTitle": "A Clinical Study to Evaluate Ianalumab in Participants With Diffuse Cutaneous Systemic Sclerosis",
+      "officialTitle": "A Randomized, Double-blind, Parallel Group, Placebo-controlled Multicenter Study to Evaluate Efficacy, Safety and Tolerability of Ianalumab in Participants With Diffuse Cutaneous Systemic Sclerosis",
+      "overallStatus": "RECRUITING",
+      "lastUpdatePostDate": "2026-07-10",
+      "conditions": [
+        "Diffuse Cutaneous Systemic Sclerosis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Ianalumab matching placebo subcutaneous (s.c.) injection as defined in the protocol"
+        },
+        {
+          "type": "DRUG",
+          "name": "Ianalumab",
+          "description": "subcutaneous (s.c.) injection as defined in the protocol"
+        }
+      ],
+      "arms": [
+        {
+          "label": "VAY736 (Ianalumab)",
+          "type": "EXPERIMENTAL",
+          "description": "Treatment Period 1: Ianalumab subcutaneous (s.c.) injection as defined in the protocol Treatment Period 2: Open-label (OL) Ianalumab subcutaneous (s.c.) injection as defined in the protocol"
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Treatment Period 1: Placebo to Ianalumab subcutaneous (s.c.) injection as defined in the protocol Treatment Period 2: Open-label (OL) Ianalumab subcutaneous (s.c.) injection as defined in the protocol"
+        }
+      ]
+    },
+    "NCT06698796": {
+      "identifier": "NCT06698796",
+      "briefTitle": "A Study to Understand How the Study Medicine Dazukibart Works in People With Idiopathic Inflammatory Myopathies",
+      "officialTitle": "A PHASE 3, MULTI-CENTER, OPEN-LABEL EXTENSION STUDY TO INVESTIGATE THE LONG-TERM SAFETY, TOLERABILITY, AND EFFICACY OF DAZUKIBART IN PARTICIPANTS WITH IDIOPATHIC INFLAMMATORY MYOPATHIES (INCLUDING PARTICIPANTS WITH DERMATOMYOSITIS OR POLYMYOSITIS)",
+      "overallStatus": "RECRUITING",
+      "lastUpdatePostDate": "2026-05-15",
+      "conditions": [
+        "Dermatomyositis",
+        "Polymyositis"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Dazukibart",
+          "description": "anti-interferon beta therapy"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Dazukibart",
+          "type": "EXPERIMENTAL",
+          "description": "Participants will receive dazukibart via intravenous infusion every 4 weeks."
+        }
+      ]
+    },
+    "NCT07011589": {
+      "identifier": "NCT07011589",
+      "briefTitle": "Targeting Collagen VII Antibodies in Bullous Diseases Using Efgartigimod IV (VYVGART)",
+      "officialTitle": "Targeting Collagen VII Antibodies in Bullous Diseases Using Efgartigimod IV (VYVGART)",
+      "overallStatus": "NOT_YET_RECRUITING",
+      "lastUpdatePostDate": "2026-05-05",
+      "conditions": [
+        "Epidermolysis Bullosa (EB)",
+        "Epidermolysis Bullosa Acquisita",
+        "Recessive Dystrophic Epidermolysis Bullosa",
+        "Dystrophic Epidermolysis Bullosa"
+      ],
+      "interventions": [
+        {
+          "type": "BIOLOGICAL",
+          "name": "Efgartigimod",
+          "description": "Dosage: 10mg/kg Frequency: Once a week Duration: 25 weeks"
+        }
+      ],
+      "arms": [
+        {
+          "label": "Efgartigimod",
+          "type": "EXPERIMENTAL",
+          "description": "There is one arm of the study. First, each participant undergoes a 3-month observational period. If the participant has DEB, they will continue their standard of care VYJUVEK as prescribed. After the observational period concludes, the participant enters the treatment period, during which Efgartigimod is administered. DEB participants will continue their standard of care VYJUVEK as prescribed."
+        }
+      ]
+    },
+    "NCT07260877": {
+      "identifier": "NCT07260877",
+      "briefTitle": "A Multicenter, Randomized, Double-Blind, Placebo-Controlled, Phase 2a Study With an Open-Label Extension Evaluating the Efficacy and Safety of VENT-03 in Adult Participants With Active Cutaneous Lupus Erythematosus With or Without Systemic Lupus Erythematosus",
+      "officialTitle": "A Multicenter, Randomized, Double-Blind, Placebo-Controlled, Phase 2a Study With an Open-Label Extension Evaluating the Efficacy and Safety of VENT-03 in Adult Participants With Active Cutaneous Lupus Erythematosus With or Without Systemic Lupus Erythematosus",
+      "overallStatus": "RECRUITING",
+      "lastUpdatePostDate": "2026-07-27",
+      "conditions": [
+        "Cutaneous Lupus Erythematosus (CLE)",
+        "Systemic Lupus Erythematosus",
+        "SLE",
+        "SLE (Systemic Lupus)",
+        "CLE"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "VENT-03",
+          "description": "VENT-03 is a tablet"
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Placebo is a tablet"
+        }
+      ],
+      "arms": [
+        {
+          "label": "VENT-03",
+          "type": "EXPERIMENTAL",
+          "description": "VENT-03"
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": "Placebo"
+        }
+      ]
+    },
+    "NCT07332481": {
+      "identifier": "NCT07332481",
+      "briefTitle": "A Study of Enpatoran in Participants With Cutaneous Manifestations of Lupus With or Without Systemic Disease",
+      "officialTitle": "A Phase 3, Randomized, Double-Blind,Placebo-Controlled Parallel Study to Evaluate the Efficacy and Safety of Enpatoran in Participants With Active Cutaneous Manifestations of Lupus Erythematosus With or Without Systemic Disease Receiving Standard of Care (ELOWEN-1)",
+      "overallStatus": "RECRUITING",
+      "lastUpdatePostDate": "2026-07-23",
+      "conditions": [
+        "Systemic Lupus Erythematosus (SLE)",
+        "Cutaneous Lupus Erythematosus (CLE)"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Enpatoran",
+          "description": "Participants will receive a dose of Enpatoran orally twice daily from Day 1 to Day 168."
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Participants will receive a single oral dose of a placebo matching Enpatoran tablet twice daily from Day 1 to Day 168."
+        },
+        {
+          "type": "DRUG",
+          "name": "Standard of care (SoC)",
+          "description": "Participants will receive Investigator-recommended SoC."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Enpatoran",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": ""
+        }
+      ]
+    },
+    "NCT07355218": {
+      "identifier": "NCT07355218",
+      "briefTitle": "A Study of Enpatoran in Participants With Cutaneous Manifestations of Lupus With or Without Systemic Disease (ELOWEN-2)",
+      "officialTitle": "A Phase 3, Randomized, Double-Blind,Placebo-Controlled Parallel Study to Evaluate the Efficacy and Safety of Enpatoran in Participants With Active Cutaneous Manifestations of Lupus Erythematosus With or Without Systemic Disease Receiving Standard of Care (ELOWEN-2)",
+      "overallStatus": "RECRUITING",
+      "lastUpdatePostDate": "2026-07-17",
+      "conditions": [
+        "Systematic Lupus Erythematosus",
+        "Cutaneous Lupus Erythematosus"
+      ],
+      "interventions": [
+        {
+          "type": "DRUG",
+          "name": "Enpatoran",
+          "description": "Participants will receive a dose of Enpatoran orally twice daily from Day 1 to Day 168."
+        },
+        {
+          "type": "DRUG",
+          "name": "Placebo",
+          "description": "Participants will receive a single oral dose of a placebo matching Enpatoran tablet twice daily from Day 1 to Day 168."
+        },
+        {
+          "type": "DRUG",
+          "name": "Standard of care (SoC)",
+          "description": "Participants will receive Investigator-recommended SoC."
+        }
+      ],
+      "arms": [
+        {
+          "label": "Enpatoran",
+          "type": "EXPERIMENTAL",
+          "description": ""
+        },
+        {
+          "label": "Placebo",
+          "type": "PLACEBO_COMPARATOR",
+          "description": ""
+        }
+      ]
+    }
+  }
+}

--- a/site/scripts/assemble-rheum-derm-dashboard.mjs
+++ b/site/scripts/assemble-rheum-derm-dashboard.mjs
@@ -4,10 +4,16 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import {
+  enhanceDashboardHtml,
+  validateEvidenceDetailRelease,
+} from './rheum-derm-evidence-details.mjs';
+
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const SITE_ROOT = path.resolve(HERE, '..');
 const DASHBOARD_DIR = path.join(SITE_ROOT, 'public', 'apps', 'rheum-derm-clinical-trials');
 const OUTPUT = path.join(DASHBOARD_DIR, 'index.html');
+const REGISTRY_SNAPSHOT = path.join(DASHBOARD_DIR, 'registry-regimens.json');
 
 // Immutable release payload. The order and membership are explicit so stray
 // historical fragments cannot enter the gzip stream through filename globbing.
@@ -31,6 +37,10 @@ const EXPECTED_ARCHIVE_BYTES = 162078;
 const EXPECTED_ARCHIVE_SHA256 = 'cc0fef45addb8c8bc97a72cc2f4de237c98878b1149bda4bf5843799bd31504d';
 const EXPECTED_HTML_BYTES = 864417;
 const EXPECTED_HTML_SHA256 = '7da4751bb81838b1dfd7be71a4209d0b90fbcea0c0235b07d6e1da2f4f4e86dc';
+const EXPECTED_REGISTRY_BYTES = 287865;
+const EXPECTED_REGISTRY_SHA256 = '0744c5d276c2122e0e4a28de39425e7878747ef57d8025c814b00f83f93df8fb';
+const EXPECTED_ENHANCED_BYTES = 1237210;
+const EXPECTED_ENHANCED_SHA256 = '5648daf1a29433105d1a4ec7b83b1bcdf3fdab201b05dbf49ee36d37e076d5a7';
 
 function sha256(value) {
   return createHash('sha256').update(value).digest('hex');
@@ -80,15 +90,15 @@ async function main() {
     throw new Error('Dashboard payload is not a gzip stream');
   }
 
-  const dashboard = gunzipSync(archive);
-  const dashboardSha256 = assertExactArtifact(
-    dashboard,
+  const sourceDashboard = gunzipSync(archive);
+  const sourceDashboardSha256 = assertExactArtifact(
+    sourceDashboard,
     EXPECTED_HTML_BYTES,
     EXPECTED_HTML_SHA256,
-    'Decoded dashboard'
+    'Decoded source dashboard'
   );
 
-  const text = dashboard.toString('utf8');
+  const text = sourceDashboard.toString('utf8');
   if (
     !text.startsWith('<!doctype html>') ||
     !text.includes('Rheum') ||
@@ -97,12 +107,46 @@ async function main() {
     throw new Error('Decoded dashboard failed content sanity checks');
   }
 
+  const registryBytes = await fs.readFile(REGISTRY_SNAPSHOT);
+  const registrySha256 = assertExactArtifact(
+    registryBytes,
+    EXPECTED_REGISTRY_BYTES,
+    EXPECTED_REGISTRY_SHA256,
+    'Registry regimen snapshot'
+  );
+  const registrySnapshot = JSON.parse(registryBytes.toString('utf8'));
+  if (
+    registrySnapshot.schemaVersion !== 1 ||
+    registrySnapshot.recordCount !== Object.keys(registrySnapshot.records || {}).length ||
+    registrySnapshot.recordCount !== 142
+  ) {
+    throw new Error('Registry regimen snapshot failed denominator checks');
+  }
+
+  const dashboard = Buffer.from(enhanceDashboardHtml(text, registrySnapshot));
+  const enhancedMatch = dashboard.toString('utf8').match(
+    /<script id="dashboard-data" type="application\/json">([\s\S]*?)<\/script>/
+  );
+  if (!enhancedMatch) throw new Error('Enhanced dashboard is missing its embedded evidence data');
+  validateEvidenceDetailRelease(JSON.parse(enhancedMatch[1]));
+  const dashboardSha256 = assertExactArtifact(
+    dashboard,
+    EXPECTED_ENHANCED_BYTES,
+    EXPECTED_ENHANCED_SHA256,
+    'Enhanced evidence-detail dashboard'
+  );
   await fs.writeFile(OUTPUT, dashboard);
   console.log(
-    `Assembled verified dashboard: ${dashboard.length} bytes, sha256 ${dashboardSha256}`
+    `Assembled evidence-detail dashboard: ${dashboard.length} bytes, sha256 ${dashboardSha256}`
   );
   console.log(
     `Verified archive: ${archive.length} bytes, sha256 ${archiveSha256}`
+  );
+  console.log(
+    `Verified immutable source dashboard: ${sourceDashboard.length} bytes, sha256 ${sourceDashboardSha256}`
+  );
+  console.log(
+    `Verified registry snapshot: ${registryBytes.length} bytes, sha256 ${registrySha256}`
   );
   console.log(`Payload source: ${SHARD_FILES.join(', ')}`);
 }

--- a/site/scripts/refresh-rheum-derm-registry-regimens.mjs
+++ b/site/scripts/refresh-rheum-derm-registry-regimens.mjs
@@ -1,0 +1,98 @@
+import { gunzipSync } from 'node:zlib';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { applyEvidenceDetailCorrections } from './rheum-derm-evidence-details.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SITE_ROOT = path.resolve(HERE, '..');
+const DASHBOARD_DIR = path.join(SITE_ROOT, 'public', 'apps', 'rheum-derm-clinical-trials');
+const OUTPUT = path.join(DASHBOARD_DIR, 'registry-regimens.json');
+const SHARD_FILES = [
+  'dashboard.00.b64',
+  'dashboard.01.b64',
+  'dashboard.02.b64',
+  'dashboard.03.b64',
+  'dashboard.04.b64',
+  'dashboard.05.b64',
+  'dashboard.06.b64',
+  'dashboard.07.b64',
+  'dashboard.08a.b64',
+  'dashboard.08b.b64',
+  'dashboard.09.b64',
+  'dashboard.10.b64',
+];
+
+function dashboardData(html) {
+  const match = html.match(/<script id="dashboard-data" type="application\/json">([\s\S]*?)<\/script>/);
+  if (!match) throw new Error('Could not locate dashboard data');
+  return JSON.parse(match[1]);
+}
+
+function identifiers(studies) {
+  return [...new Set(studies.flatMap(study => String(study.nct || '').match(/NCT\d{8}/g) || []))].sort();
+}
+
+function compactRecord(identifier, payload) {
+  const protocol = payload.protocolSection || {};
+  const identification = protocol.identificationModule || {};
+  const status = protocol.statusModule || {};
+  const arms = protocol.armsInterventionsModule || {};
+  return {
+    identifier,
+    briefTitle: identification.briefTitle || '',
+    officialTitle: identification.officialTitle || '',
+    overallStatus: status.overallStatus || '',
+    lastUpdatePostDate: status.lastUpdatePostDateStruct?.date || '',
+    conditions: protocol.conditionsModule?.conditions || [],
+    interventions: (arms.interventions || []).map(intervention => ({
+      type: intervention.type || '',
+      name: intervention.name || '',
+      description: String(intervention.description || '').replace(/\s+/g, ' ').trim(),
+    })),
+    arms: (arms.armGroups || []).map(arm => ({
+      label: arm.label || '',
+      type: arm.type || '',
+      description: String(arm.description || '').replace(/\s+/g, ' ').trim(),
+    })),
+  };
+}
+
+async function fetchRecord(identifier) {
+  const response = await fetch(`https://clinicaltrials.gov/api/v2/studies/${identifier}`);
+  if (!response.ok) throw new Error(`${identifier}: ClinicalTrials.gov returned HTTP ${response.status}`);
+  return compactRecord(identifier, await response.json());
+}
+
+async function main() {
+  const encoded = (await Promise.all(SHARD_FILES.map(name => fs.readFile(path.join(DASHBOARD_DIR, name), 'utf8'))))
+    .join('')
+    .replace(/\s+/g, '');
+  const sourceHtml = gunzipSync(Buffer.from(encoded, 'base64')).toString('utf8');
+  const corrected = applyEvidenceDetailCorrections(dashboardData(sourceHtml), { records: {} });
+  const requested = identifiers(corrected.studies);
+  const records = {};
+  let cursor = 0;
+
+  async function worker() {
+    while (cursor < requested.length) {
+      const identifier = requested[cursor++];
+      records[identifier] = await fetchRecord(identifier);
+    }
+  }
+
+  await Promise.all(Array.from({ length: 8 }, worker));
+  const orderedRecords = Object.fromEntries(Object.entries(records).sort(([a], [b]) => a.localeCompare(b)));
+  const snapshot = {
+    schemaVersion: 1,
+    retrievedAt: new Date().toISOString().slice(0, 10),
+    source: 'https://clinicaltrials.gov/api/v2/studies/{NCT_ID}',
+    recordCount: Object.keys(orderedRecords).length,
+    records: orderedRecords,
+  };
+  await fs.writeFile(OUTPUT, `${JSON.stringify(snapshot, null, 2)}\n`);
+  console.log(`Wrote ${snapshot.recordCount} registry regimen records to ${OUTPUT}`);
+}
+
+await main();

--- a/site/scripts/rheum-derm-evidence-details.mjs
+++ b/site/scripts/rheum-derm-evidence-details.mjs
@@ -1,0 +1,364 @@
+const DATA_PATTERN = /(<script id="dashboard-data" type="application\/json">)([\s\S]*?)(<\/script>)/;
+
+const QUARANTINE_STATE = 'Source mismatch / Quarantined';
+const QUARANTINE_COLOR = '#991b1b';
+
+const STUDY_CORRECTIONS = {
+  's064-phase-2-iberdomide-sle-trial': {
+    trial: 'Iberdomide dose-ranging phase 2 SLE trial',
+    administration: 'Oral iberdomide 0.15 mg, 0.30 mg, or 0.45 mg once daily versus placebo for 24 weeks.',
+    regimenSummary: 'Oral iberdomide 0.15 mg, 0.30 mg, or 0.45 mg once daily versus placebo for 24 weeks.',
+    regimenDetailStatus: 'registry-dose',
+    sourceVerification: 'ClinicalTrials.gov NCT03161483 identifies the 0.15 mg, 0.30 mg, and 0.45 mg once-daily arms.',
+  },
+  's081-phase-2-skin-predominant-dm-trial': {
+    trial: 'Lenabasum skin-predominant dermatomyositis phase 2 trial',
+  },
+  's082-resolve-1': {
+    trial: 'DETERMINE',
+    nct: 'NCT03813160',
+    registryUrl: 'https://clinicaltrials.gov/study/NCT03813160',
+    administration: 'Oral lenabasum 20 mg twice daily, 5 mg twice daily, or placebo twice daily; planned for 52 weeks and stopped after all participants completed week 28.',
+    regimenSummary: 'Oral lenabasum 20 mg twice daily, 5 mg twice daily, or placebo twice daily; planned for 52 weeks and stopped after all participants completed week 28.',
+    regimenDetailStatus: 'registry-dose',
+    sourceVerification: 'Registry identity corrected to DETERMINE (NCT03813160). The previously listed NCT03398837 is RESOLVE-1 in diffuse cutaneous systemic sclerosis, not dermatomyositis.',
+    notes: 'Registry identifier corrected from the unrelated SSc RESOLVE-1 record NCT03398837 to the dermatomyositis DETERMINE record NCT03813160.',
+  },
+  's085-phase-2-randomized-trial': {
+    trial: 'Brepocitinib adult dermatomyositis phase 2 record — quarantined',
+    displayTitle: 'Brepocitinib for adult dermatomyositis — quarantined source-mismatched record',
+    administration: 'Dose not reportable: the cited registry does not describe brepocitinib or dermatomyositis.',
+    regimenSummary: 'Dose not reportable: the cited registry does not describe brepocitinib or dermatomyositis.',
+    regimenDetailStatus: 'source-mismatch',
+    category: 'Unverified — source mismatch',
+    grade: 'U',
+    status: 'Quarantined pending a correct primary source; excluded from efficacy interpretation.',
+    evidenceState: QUARANTINE_STATE,
+    metrics: 'No verified phase 2 efficacy result is reported. The cited NCT04027101 is BACHELOR, a baricitinib trial in polymyalgia rheumatica. The verified brepocitinib dermatomyositis evidence is the separately listed VALOR phase 3 trial (NCT05437263).',
+    finding: 'Source mismatch; no phase 2 efficacy inference is retained.',
+    impact: 'None assigned. This record is quarantined until a matching primary source is supplied.',
+    caveats: 'The prior registry identifier, disease, intervention, sample, dosing, and efficacy narrative did not resolve to the same study.',
+    nct: '',
+    doi: '',
+    sourceUrl: '',
+    registryUrl: '',
+    citation: 'Quarantined dashboard record. Rejected identifier: NCT04027101 (BACHELOR; baricitinib in polymyalgia rheumatica). No matching brepocitinib dermatomyositis phase 2 primary source verified as of 2026-08-12.',
+    citationType: 'Quarantined source-mismatch record',
+    sourceVerification: 'Rejected NCT04027101: the registry describes baricitinib for polymyalgia rheumatica, not brepocitinib for dermatomyositis.',
+    notes: 'Quarantined on 2026-08-12 after direct ClinicalTrials.gov identity reconciliation.',
+  },
+  's087-phase-2-proof-of-concept': {
+    trial: 'Dazukibart phase 2 dermatomyositis trial',
+    nct: 'NCT03181893',
+    registryUrl: 'https://clinicaltrials.gov/study/NCT03181893',
+    administration: 'Intravenous dazukibart 150 mg or 600 mg every 4 weeks for 3 doses versus placebo.',
+    regimenSummary: 'Intravenous dazukibart 150 or 600 mg every 4 weeks for 3 doses versus placebo.',
+    regimenDetailStatus: 'publication-dose',
+    sourceVerification: 'Dose and schedule verified against the primary Lancet report, DOI 10.1016/S0140-6736(24)02071-3 (trial registration NCT03181893).',
+  },
+  's088-phase-3-program-open-label-extension': {
+    trial: 'Dazukibart phase 3 IIM open-label extension',
+    administration: 'Intravenous dazukibart every 4 weeks; the numeric dose is not disclosed in the public registry record.',
+    regimenSummary: 'Intravenous dazukibart every 4 weeks; numeric dose not disclosed in the public registry record.',
+    regimenDetailStatus: 'registry-schedule',
+  },
+  's066-willow-elowen-program': {
+    nNumeric: 400,
+  },
+  's111-phase-2-and-resolve-1': {
+    trial: 'Lenabasum SSc program: phase 2 and RESOLVE-1',
+    administration: 'Oral lenabasum 5 mg or 20 mg twice daily versus placebo in RESOLVE-1.',
+    regimenSummary: 'Oral lenabasum 5 mg or 20 mg twice daily versus placebo in RESOLVE-1.',
+    regimenDetailStatus: 'registry-dose',
+    nNumeric: 365,
+  },
+  's116-rapids-2': {
+    administration: 'Oral bosentan 62.5 mg twice daily for 4 weeks, then 125 mg twice daily for 20 weeks, versus placebo.',
+    regimenSummary: 'Oral bosentan 62.5 mg twice daily for 4 weeks, then 125 mg twice daily for 20 weeks, versus placebo.',
+    regimenDetailStatus: 'publication-dose',
+    nct: '',
+    registryUrl: '',
+    sourceVerification: 'Primary publication verified by DOI 10.1136/ard.2010.130658. The previously listed NCT00301795 is an unrelated follicular-lymphoma trial and was removed.',
+    notes: 'Removed unrelated lymphoma registry NCT00301795; identity and regimen verified against the RAPIDS-2 primary publication.',
+  },
+  's148-blister': {
+    nct: 'ISRCTN13704604',
+    registryUrl: 'https://www.isrctn.com/ISRCTN13704604',
+    sourceVerification: 'Registry identity corrected to ISRCTN13704604. The previously listed NCT02226146 is a bertilimumab bullous-pemphigoid study, not BLISTER.',
+    notes: 'Registry identifier corrected from unrelated NCT02226146 to ISRCTN13704604.',
+  },
+  's187-thalidomide-rct': {
+    trial: 'Thalidomide mucocutaneous Behçet randomized trial',
+  },
+  's189-phase-2-apremilast-trial': {
+    trial: 'Apremilast Behçet oral-ulcer phase 2 trial',
+  },
+};
+
+const GENERIC_TITLE = /^(?:phase\s*[123](?:a|b)?|randomi[sz]ed(?: controlled)? trial|open-label trial|prospective study)/i;
+const DOSE_PATTERN = /(?:\b\d+(?:\.\d+)?\s*(?:mg|g|mcg|µg|ug|units?|iu|mL|ml|%)(?=\s|[),.;/]|$)|\b\d+(?:\.\d+)?\s*(?:mg|g|mcg|µg|ug)\s*\/\s*(?:kg|day|week|m2|m²)(?=\s|[),.;/]|$)|\b\d+(?:\.\d+)?\s*(?:J|mJ)\s*\/\s*cm(?:2|²)(?=\s|[),.;/]|$))/i;
+const VARIABLE_REGIMEN_PATTERN = /(?:systematic review|meta-analysis|network meta-analysis|evidence synthesis|case series|cohort evidence|across .* trials|no single administration)/i;
+
+export const EVIDENCE_DETAIL_RELEASE_EXPECTATIONS = Object.freeze({
+  studies: 214,
+  quarantined: 1,
+  regimenDetailCounts: Object.freeze({
+    'record-dose': 72,
+    'registry-dose': 31,
+    'publication-dose': 2,
+    'variable-regimen': 18,
+    'registry-schedule': 1,
+    'dose-not-reported': 89,
+    'source-mismatch': 1,
+  }),
+});
+
+function lowerInitial(value) {
+  if (!value) return '';
+  return value[0].toLowerCase() + value.slice(1);
+}
+
+function unique(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function registryIdentifiers(value) {
+  return String(value || '').match(/NCT\d{8}/g) || [];
+}
+
+function registryDoseDetails(record) {
+  if (!record) return [];
+  const arms = Array.isArray(record.arms) ? record.arms : [];
+  const interventions = Array.isArray(record.interventions) ? record.interventions : [];
+  return unique([...arms, ...interventions]
+    .flatMap(item => [item.description, item.name])
+    .map(value => String(value || '').replace(/\s+/g, ' ').trim())
+    .filter(description => DOSE_PATTERN.test(description)));
+}
+
+export function buildDisplayTitle(study) {
+  if (study.displayTitle) return study.displayTitle;
+  const trial = String(study.trial || '').trim();
+  const intervention = String(study.intervention || 'Intervention').trim();
+  const condition = String(study.condition || 'the listed condition').trim();
+  if (GENERIC_TITLE.test(trial)) {
+    return `${intervention} for ${lowerInitial(condition)} — ${lowerInitial(trial)}`;
+  }
+
+  const normalizedTrial = trial.toLowerCase();
+  const interventionKey = intervention.toLowerCase().split(/[\s/+(]/)[0];
+  if (interventionKey.length > 3 && normalizedTrial.includes(interventionKey)) {
+    return `${trial} — ${condition}`;
+  }
+  return `${trial} — ${intervention} for ${condition}`;
+}
+
+function regimenStatusLabel(status) {
+  return ({
+    'record-dose': 'Dose and schedule reported in the normalized record',
+    'registry-dose': 'Dose detail reconciled to linked ClinicalTrials.gov arms',
+    'publication-dose': 'Dose detail reconciled to the primary publication',
+    'registry-schedule': 'Schedule reported; numeric dose absent from the public registry record',
+    'variable-regimen': 'No single dose applies across the included evidence',
+    'dose-not-reported': 'Numeric dose not reported in the current normalized record',
+    'source-mismatch': 'Do not use: source identity mismatch',
+  })[status] || 'Regimen detail status unknown';
+}
+
+export function applyEvidenceDetailCorrections(inputApp, registrySnapshot = { records: {} }) {
+  const app = structuredClone(inputApp);
+  app.evidenceColors ||= {};
+  app.evidenceColors[QUARANTINE_STATE] = QUARANTINE_COLOR;
+  const registryRecords = registrySnapshot.records || {};
+
+  app.studies = (app.studies || []).map(original => {
+    const study = { ...original, ...(STUDY_CORRECTIONS[original.id] || {}) };
+    const ids = registryIdentifiers(study.nct);
+    const records = ids.map(identifier => ({ identifier, record: registryRecords[identifier] })).filter(item => item.record);
+    const doseDetails = unique(records.flatMap(item => registryDoseDetails(item.record)));
+
+    study.regimenSources = records.map(({ identifier, record }) => ({
+      identifier,
+      title: record.briefTitle || record.officialTitle || identifier,
+      checked: record.lastUpdatePostDate || registrySnapshot.retrievedAt || 'not recorded',
+      url: `https://clinicaltrials.gov/study/${identifier}`,
+    }));
+    study.regimenDetails = doseDetails;
+
+    if (!study.regimenSummary) {
+      if (DOSE_PATTERN.test(study.administration || '')) {
+        study.regimenSummary = study.administration;
+        study.regimenDetailStatus = 'record-dose';
+      } else if (doseDetails.length) {
+        study.regimenSummary = doseDetails.join(' ');
+        study.regimenDetailStatus = 'registry-dose';
+      } else if (VARIABLE_REGIMEN_PATTERN.test(`${study.design || ''} ${study.administration || ''} ${study.trial || ''}`)) {
+        study.regimenSummary = `${study.administration} No single dose applies across the included evidence.`;
+        study.regimenDetailStatus = 'variable-regimen';
+      } else {
+        study.regimenSummary = `${study.administration || 'Administration not reported.'} Numeric dose is not reported in the current normalized record.`;
+        study.regimenDetailStatus = 'dose-not-reported';
+      }
+    }
+
+    study.regimenStatusLabel = regimenStatusLabel(study.regimenDetailStatus);
+    study.sourceVerification ||= ids.length
+      ? `Linked registry identifier${ids.length === 1 ? '' : 's'}: ${ids.join(', ')}.`
+      : 'No ClinicalTrials.gov identifier is recorded; use the cited primary publication or source record.';
+    study.displayTitle = buildDisplayTitle(study);
+    study.originalRecordLabel = original.trial;
+    study.searchText = [
+      original.searchText,
+      study.displayTitle,
+      study.regimenSummary,
+      study.regimenStatusLabel,
+      study.sourceVerification,
+      ...study.regimenDetails,
+    ].filter(Boolean).join(' ').toLowerCase();
+    return study;
+  });
+
+  const counts = {};
+  for (const study of app.studies) counts[study.evidenceState] = (counts[study.evidenceState] || 0) + 1;
+  app.stateCounts = { ...(app.stateCounts || {}), ...counts };
+  for (const key of Object.keys(app.stateCounts)) {
+    if (!counts[key]) app.stateCounts[key] = 0;
+  }
+  app.meta ||= {};
+  app.meta.evidenceDetailRevision = '2026-08-12';
+  app.meta.sourceMismatchQuarantined = counts[QUARANTINE_STATE] || 0;
+  app.meta.regimenDetailCounts = app.studies.reduce((result, study) => {
+    result[study.regimenDetailStatus] = (result[study.regimenDetailStatus] || 0) + 1;
+    return result;
+  }, {});
+  return app;
+}
+
+export function validateEvidenceDetailRelease(app) {
+  const expected = EVIDENCE_DETAIL_RELEASE_EXPECTATIONS;
+  const studies = app.studies || [];
+  if (studies.length !== expected.studies) {
+    throw new Error(`Evidence-detail study denominator ${studies.length}; expected ${expected.studies}`);
+  }
+
+  const titles = studies.map(study => String(study.displayTitle || '').trim());
+  if (titles.some(title => !title)) throw new Error('Evidence-detail release contains a blank display title');
+  if (new Set(titles).size !== studies.length) {
+    throw new Error('Evidence-detail release contains a duplicate display title');
+  }
+  if (titles.some(title => GENERIC_TITLE.test(title))) {
+    throw new Error('Evidence-detail release contains a generic display title');
+  }
+
+  const actualCounts = app.meta?.regimenDetailCounts || {};
+  for (const [status, expectedCount] of Object.entries(expected.regimenDetailCounts)) {
+    if (actualCounts[status] !== expectedCount) {
+      throw new Error(`Evidence-detail ${status} count ${actualCounts[status] ?? 0}; expected ${expectedCount}`);
+    }
+  }
+  const unexpectedStatuses = Object.keys(actualCounts).filter(status => !(status in expected.regimenDetailCounts));
+  if (unexpectedStatuses.length) {
+    throw new Error(`Evidence-detail release contains unexpected regimen statuses: ${unexpectedStatuses.join(', ')}`);
+  }
+  const regimenDenominator = Object.values(actualCounts).reduce((sum, count) => sum + count, 0);
+  if (regimenDenominator !== studies.length) {
+    throw new Error(`Evidence-detail regimen denominator ${regimenDenominator}; expected ${studies.length}`);
+  }
+  if (app.meta?.sourceMismatchQuarantined !== expected.quarantined) {
+    throw new Error(`Evidence-detail quarantine count ${app.meta?.sourceMismatchQuarantined ?? 0}; expected ${expected.quarantined}`);
+  }
+
+  const byId = new Map(studies.map(study => [study.id, study]));
+  const correctedIdentityChecks = [
+    ['s082-resolve-1', 'NCT03813160'],
+    ['s087-phase-2-proof-of-concept', 'NCT03181893'],
+    ['s116-rapids-2', ''],
+    ['s148-blister', 'ISRCTN13704604'],
+    ['s085-phase-2-randomized-trial', ''],
+  ];
+  for (const [id, expectedIdentifier] of correctedIdentityChecks) {
+    const study = byId.get(id);
+    if (!study || study.nct !== expectedIdentifier) {
+      throw new Error(`Evidence-detail identity check failed for ${id}`);
+    }
+  }
+  if (byId.get('s085-phase-2-randomized-trial')?.regimenDetailStatus !== 'source-mismatch') {
+    throw new Error('Evidence-detail brepocitinib mismatch is not quarantined');
+  }
+  return app;
+}
+
+function replaceAllRequired(text, needle, replacement, label = needle) {
+  if (!text.includes(needle)) throw new Error(`Dashboard evidence-detail transform could not find ${label}`);
+  return text.split(needle).join(replacement);
+}
+
+export function enhanceDashboardHtml(sourceHtml, registrySnapshot = { records: {} }) {
+  const match = sourceHtml.match(DATA_PATTERN);
+  if (!match) throw new Error('Dashboard evidence-detail transform could not locate embedded data');
+  const app = applyEvidenceDetailCorrections(JSON.parse(match[2]), registrySnapshot);
+  let html = sourceHtml.replace(DATA_PATTERN, `$1${JSON.stringify(app)}$3`);
+
+  const styles = `
+.study-route { -webkit-line-clamp: 4; }
+.study-regimen-label { display: block; margin-bottom: 3px; color: var(--muted-2); font-size: 9px; font-weight: 800; letter-spacing: .07em; text-transform: uppercase; }
+.regimen-status { display: inline-flex; align-items: center; width: fit-content; margin-top: 7px; padding: 3px 7px; border: 1px solid var(--line); border-radius: 6px; background: var(--surface-2); color: var(--muted); font-size: 9px; font-weight: 700; }
+.regimen-status.source-mismatch { border-color: #fecaca; background: #fef2f2; color: #991b1b; }
+.regimen-detail-list { margin: 9px 0 0; padding-left: 18px; color: var(--muted); font-size: 11px; }
+.source-verification-warning { color: #991b1b; font-weight: 700; }
+`;
+  html = replaceAllRequired(html, '</style>', `${styles}</style>`, 'closing style tag');
+
+  html = replaceAllRequired(html, 'highlight(s.trial)', 'highlight(s.displayTitle)', 'highlighted trial labels');
+  html = replaceAllRequired(html, 'escapeHtml(s.trial)', 'escapeHtml(s.displayTitle)', 'escaped trial labels');
+  html = html.split('${s.trial}').join('${s.displayTitle}');
+  html = replaceAllRequired(html, 'highlight(s.administration)', 'highlight(s.regimenSummary)', 'highlighted administration text');
+  html = replaceAllRequired(html, 'escapeHtml(s.administration)', 'escapeHtml(s.regimenSummary)', 'escaped administration text');
+  html = html.split('${s.administration}').join('${s.regimenSummary}');
+  html = html.split('s=>s.administration').join('s=>s.regimenSummary');
+  html = html.split("'Administration'").join("'Study regimen'");
+  html = html.split('Administration:').join('Study regimen:');
+  html = html.split('Intervention / route').join('Intervention / study regimen');
+
+  const plainRegimen = '<div class="study-route">${highlight(s.regimenSummary)}</div>';
+  if (html.includes(plainRegimen)) {
+    html = html.split(plainRegimen).join('<div class="study-route"><span class="study-regimen-label">Study regimen</span>${highlight(s.regimenSummary)}</div><div class="regimen-status ${escapeHtml(s.regimenDetailStatus)}">${escapeHtml(s.regimenStatusLabel)}</div>');
+  } else {
+    html = html.replace(/<div class="study-route">\$\{highlight\(s\.regimenSummary\)\}<\/div>/g, '<div class="study-route"><span class="study-regimen-label">Study regimen</span>${highlight(s.regimenSummary)}</div><div class="regimen-status ${escapeHtml(s.regimenDetailStatus)}">${escapeHtml(s.regimenStatusLabel)}</div>');
+  }
+
+  const detailSection = '<section class="detail-section"><h3>Administration</h3><p>${escapeHtml(s.regimenSummary)}</p></section>';
+  const renamedDetailSection = '<section class="detail-section"><h3>Study regimen</h3><p>${escapeHtml(s.regimenSummary)}<br><span class="regimen-status ${escapeHtml(s.regimenDetailStatus)}">${escapeHtml(s.regimenStatusLabel)}</span></p>${s.regimenDetails?.length?`<ul class="regimen-detail-list">${s.regimenDetails.map(detail=>`<li>${escapeHtml(detail)}</li>`).join(\'\')}</ul>`:\'\'}</section>';
+  if (html.includes(detailSection)) html = html.replace(detailSection, renamedDetailSection);
+  else {
+    const alreadyRenamed = '<section class="detail-section"><h3>Study regimen</h3><p>${escapeHtml(s.regimenSummary)}</p></section>';
+    if (html.includes(alreadyRenamed)) html = html.replace(alreadyRenamed, renamedDetailSection);
+  }
+
+  const notesMetadata = '<div class="metadata-key">Verification notes</div><div>${escapeHtml(s.notes||\'—\')}</div>';
+  const verificationMetadata = '<div class="metadata-key">Original record label</div><div>${escapeHtml(s.originalRecordLabel||\'—\')}</div><div class="metadata-key">Source verification</div><div class="${s.regimenDetailStatus===\'source-mismatch\'?\'source-verification-warning\':\'\'}">${escapeHtml(s.sourceVerification||\'—\')}</div><div class="metadata-key">Regimen provenance</div><div>${escapeHtml(s.regimenStatusLabel||\'—\')}</div><div class="metadata-key">Verification notes</div><div>${escapeHtml(s.notes||\'—\')}</div>';
+  if (html.includes(notesMetadata)) html = html.replace(notesMetadata, verificationMetadata);
+  else if (html.includes('Verification notes')) html = html.replace('Verification notes', 'Source verification / notes');
+
+  html = html.replace(
+    "const order = ['Landmark / Pivotal','Comparative / Randomized','Emerging / Active','Observational / Supportive','Negative / Neutral','Critical / Retracted'];",
+    "const order = ['Landmark / Pivotal','Comparative / Randomized','Emerging / Active','Observational / Supportive','Negative / Neutral','Critical / Retracted','Source mismatch / Quarantined'];",
+  );
+  html = html.replace(
+    "const fields=['trial','year'",
+    "const fields=['displayTitle','trial','year'",
+  );
+  html = html.replace(
+    "'intervention','administration','target'",
+    "'intervention','regimenSummary','regimenDetailStatus','administration','target'",
+  );
+  html = html.replace(
+    "'citation','sourceUrl','registryUrl'",
+    "'citation','sourceVerification','sourceUrl','registryUrl'",
+  );
+
+  if (!html.includes('regimenDetailStatus') || !html.includes('displayTitle') || !html.includes('Source verification')) {
+    throw new Error('Dashboard evidence-detail transform failed its output contract');
+  }
+  return html;
+}

--- a/site/scripts/rheum-derm-evidence-details.test.mjs
+++ b/site/scripts/rheum-derm-evidence-details.test.mjs
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  applyEvidenceDetailCorrections,
+  buildDisplayTitle,
+  enhanceDashboardHtml,
+} from './rheum-derm-evidence-details.mjs';
+
+const baseStudy = {
+  id: 'generic-phase-2',
+  domain: 'Dermatomyositis',
+  condition: 'Adult dermatomyositis',
+  intervention: 'Examplemab',
+  administration: 'Intravenous infusions.',
+  trial: 'Phase 2 randomized trial',
+  design: 'Phase 2 randomized placebo-controlled trial',
+  nct: 'NCT00000001',
+  evidenceState: 'Emerging / Active',
+  searchText: 'phase 2 randomized trial examplemab dermatomyositis',
+};
+
+test('generic study labels become identifiable from the listing', () => {
+  assert.equal(
+    buildDisplayTitle(baseStudy),
+    'Examplemab for adult dermatomyositis — phase 2 randomized trial',
+  );
+});
+
+test('linked registry arm dosing is promoted into the study regimen with provenance', () => {
+  const app = {
+    evidenceColors: {},
+    stateCounts: { 'Emerging / Active': 1 },
+    studies: [{ ...baseStudy }],
+  };
+  const registry = {
+    records: {
+      NCT00000001: {
+        briefTitle: 'Examplemab in Dermatomyositis',
+        lastUpdatePostDate: '2026-08-01',
+        arms: [
+          {
+            label: 'Examplemab',
+            type: 'EXPERIMENTAL',
+            description: 'Examplemab 600 mg intravenously every 4 weeks for 3 doses.',
+          },
+        ],
+      },
+    },
+  };
+
+  const enhanced = applyEvidenceDetailCorrections(app, registry);
+  const study = enhanced.studies[0];
+  assert.equal(study.regimenDetailStatus, 'registry-dose');
+  assert.equal(
+    study.regimenSummary,
+    'Examplemab 600 mg intravenously every 4 weeks for 3 doses.',
+  );
+  assert.deepEqual(study.regimenSources, [
+    {
+      identifier: 'NCT00000001',
+      title: 'Examplemab in Dermatomyositis',
+      checked: '2026-08-01',
+      url: 'https://clinicaltrials.gov/study/NCT00000001',
+    },
+  ]);
+});
+
+test('the source-mismatched brepocitinib row is quarantined instead of relabeled as efficacy evidence', () => {
+  const app = {
+    evidenceColors: { 'Observational / Supportive': '#64748b' },
+    stateCounts: { 'Observational / Supportive': 1 },
+    studies: [{
+      ...baseStudy,
+      id: 's085-phase-2-randomized-trial',
+      intervention: 'Brepocitinib',
+      nct: 'NCT04027101',
+    }],
+  };
+
+  const enhanced = applyEvidenceDetailCorrections(app, { records: {} });
+  const study = enhanced.studies[0];
+  assert.equal(study.evidenceState, 'Source mismatch / Quarantined');
+  assert.equal(study.grade, 'U');
+  assert.match(study.displayTitle, /quarantined/i);
+  assert.match(study.metrics, /No verified phase 2 efficacy result/i);
+  assert.match(study.sourceVerification, /NCT04027101.*polymyalgia rheumatica/i);
+  assert.equal(enhanced.stateCounts['Observational / Supportive'], 0);
+  assert.equal(enhanced.stateCounts['Source mismatch / Quarantined'], 1);
+});
+
+test('known registry identity defects and high-value dosing omissions are corrected', () => {
+  const studies = [
+    { ...baseStudy, id: 's082-resolve-1', trial: 'RESOLVE-1', intervention: 'Lenabasum', nct: 'NCT03398837' },
+    { ...baseStudy, id: 's087-phase-2-proof-of-concept', trial: 'Phase 2 proof-of-concept', intervention: 'Dazukibart', nct: '' },
+    { ...baseStudy, id: 's116-rapids-2', trial: 'RAPIDS-2', intervention: 'Bosentan', condition: 'SSc digital-ulcer disease', nct: 'NCT00301795' },
+    { ...baseStudy, id: 's148-blister', trial: 'BLISTER', intervention: 'Doxycycline-initiated strategy', condition: 'Bullous pemphigoid', nct: 'NCT02226146' },
+  ];
+  const app = {
+    evidenceColors: {},
+    stateCounts: { 'Emerging / Active': studies.length },
+    studies,
+  };
+
+  const enhanced = applyEvidenceDetailCorrections(app, { records: {} });
+  const byId = new Map(enhanced.studies.map(study => [study.id, study]));
+
+  assert.equal(byId.get('s082-resolve-1').trial, 'DETERMINE');
+  assert.equal(byId.get('s082-resolve-1').nct, 'NCT03813160');
+  assert.match(byId.get('s082-resolve-1').regimenSummary, /20 mg twice daily/i);
+
+  assert.match(byId.get('s087-phase-2-proof-of-concept').regimenSummary, /150 or 600 mg.*every 4 weeks.*3 doses/i);
+  assert.equal(byId.get('s087-phase-2-proof-of-concept').regimenDetailStatus, 'publication-dose');
+
+  assert.equal(byId.get('s116-rapids-2').nct, '');
+  assert.match(byId.get('s116-rapids-2').regimenSummary, /62\.5 mg twice daily.*125 mg twice daily/i);
+  assert.match(byId.get('s116-rapids-2').notes, /unrelated lymphoma registry/i);
+
+  assert.equal(byId.get('s148-blister').nct, 'ISRCTN13704604');
+  assert.equal(byId.get('s148-blister').registryUrl, 'https://www.isrctn.com/ISRCTN13704604');
+});
+
+test('dashboard HTML exposes identifiable titles, regimen status, and source verification', () => {
+  const app = {
+    evidenceColors: { 'Emerging / Active': '#7c3aed' },
+    stateCounts: { 'Emerging / Active': 1 },
+    studies: [{ ...baseStudy }],
+  };
+  const fixture = `<!doctype html><style>.study-route { color: gray; }</style><script id="dashboard-data" type="application/json">${JSON.stringify(app)}</script><script>
+const studies = APP.studies;
+const order = ['Landmark / Pivotal','Comparative / Randomized','Emerging / Active','Observational / Supportive','Negative / Neutral','Critical / Retracted'];
+function cardHtml(s) { return \`<button>\${highlight(s.trial)}</button><div class="study-route">\${highlight(s.administration)}</div>\`; }
+function tableHtml(rows) { return \`<div>\${highlight(s.trial)} \${highlight(s.administration)}</div>\`; }
+function renderCompareTray(){ return escapeHtml(s.trial); }
+function openDetail(){ return \`<h2>\${escapeHtml(s.trial)}</h2><section class="detail-section"><h3>Administration</h3><p>\${escapeHtml(s.administration)}</p></section><div class="metadata-key">Verification notes</div><div>\${escapeHtml(s.notes||'—')}</div>\`; }
+function studySummary(s){return \`\${s.trial}\nAdministration: \${s.administration}\`;}
+function openCompare(){ const rows=[['Administration',s=>s.administration]]; return escapeHtml(s.trial); }
+function exportCsv(){const fields=['trial','administration'];}
+</script>`;
+
+  const output = enhanceDashboardHtml(fixture, { records: {} });
+  assert.match(output, /Study regimen/);
+  assert.match(output, /regimenDetailStatus/);
+  assert.match(output, /displayTitle/);
+  assert.match(output, /Source verification/);
+  assert.doesNotMatch(output, /\$\{highlight\(s\.trial\)\}/);
+});

--- a/site/tests/rheum-derm-clinical-trials.spec.ts
+++ b/site/tests/rheum-derm-clinical-trials.spec.ts
@@ -1,0 +1,110 @@
+import { expect, test } from '@playwright/test'
+import { blockExternalRequests, watchRuntime } from './helpers/network.js'
+import { setDeterministicUi } from './helpers/nav.js'
+
+const APP_ROUTE = '/apps/rheum-derm-clinical-trials/'
+
+test.describe('Rheum–Derm Clinical Trials Evidence Dashboard', () => {
+  test.beforeEach(async ({ page }) => {
+    await setDeterministicUi(page, { width: 1440, height: 1000 })
+    await blockExternalRequests(page)
+  })
+
+  test('preserves the 214-row denominator while making every listing identifiable', async ({ page }) => {
+    const runtime = watchRuntime(page)
+    await page.goto(`${APP_ROUTE}#view=studies`, { waitUntil: 'networkidle' })
+
+    const audit = await page.locator('#dashboard-data').evaluate(element => {
+      const app = JSON.parse(element.textContent || '{}')
+      const generic = /^(?:phase\s*[123](?:a|b)?|randomi[sz]ed(?: controlled)? trial|open-label trial|prospective study)/i
+      return {
+        studies: app.studies.length,
+        displayTitles: app.studies.filter((study: { displayTitle?: string }) => Boolean(study.displayTitle)).length,
+        genericDisplayTitles: app.studies.filter((study: { displayTitle?: string }) => generic.test(study.displayTitle || '')).length,
+        uniqueDisplayTitles: new Set(app.studies.map((study: { displayTitle: string }) => study.displayTitle)).size,
+        regimenStatuses: Object.values(app.meta.regimenDetailCounts as Record<string, number>)
+          .reduce((total: number, count) => total + count, 0),
+        quarantined: app.meta.sourceMismatchQuarantined,
+      }
+    })
+
+    expect(audit).toEqual({
+      studies: 214,
+      displayTitles: 214,
+      genericDisplayTitles: 0,
+      uniqueDisplayTitles: 214,
+      regimenStatuses: 214,
+      quarantined: 1,
+    })
+    await expect(page.locator('.study-card').first().locator('.study-regimen-label')).toHaveText('Study regimen')
+    await expect(page.locator('.study-card').first().locator('.regimen-status')).not.toBeEmpty()
+
+    runtime.assertClean()
+  })
+
+  test('shows source-backed dosing and corrected names for the cited examples', async ({ page }) => {
+    const runtime = watchRuntime(page)
+    await page.goto(`${APP_ROUTE}#view=studies&q=dazukibart`, { waitUntil: 'networkidle' })
+
+    const phase2 = page.locator('.study-card').filter({
+      has: page.locator('[data-study="s087-phase-2-proof-of-concept"]'),
+    }).first()
+    await expect(phase2).toContainText('Dazukibart phase 2 dermatomyositis trial')
+    await expect(phase2).toContainText('150 or 600 mg every 4 weeks for 3 doses')
+    await phase2.getByRole('button', { name: 'Details' }).click()
+    await expect(page.getByRole('heading', { level: 2, name: /Dazukibart phase 2 dermatomyositis trial/ })).toBeVisible()
+    await expect(page.getByRole('heading', { level: 3, name: 'Study regimen' })).toBeVisible()
+    await expect(page.locator('#detailDialog').getByText('Dose detail reconciled to the primary publication').first()).toBeVisible()
+    await page.getByRole('button', { name: 'Close' }).click()
+
+    await page.locator('#globalSearch').fill('DETERMINE')
+    const determine = page.locator('.study-card').filter({
+      has: page.locator('[data-study="s082-resolve-1"]'),
+    }).first()
+    await expect(determine).toContainText('DETERMINE — Lenabasum for Adult dermatomyositis')
+    await expect(determine).toContainText('20 mg twice daily')
+
+    runtime.assertClean()
+  })
+
+  test('quarantines the mismatched brepocitinib record and exposes the rejected identifier', async ({ page }) => {
+    const runtime = watchRuntime(page)
+    await page.goto(`${APP_ROUTE}#view=studies&q=brepocitinib`, { waitUntil: 'networkidle' })
+
+    const quarantined = page.locator('.study-card').filter({
+      has: page.locator('[data-study="s085-phase-2-randomized-trial"]'),
+    }).first()
+    await expect(quarantined).toContainText('quarantined source-mismatched record')
+    await expect(quarantined).toContainText('Do not use: source identity mismatch')
+    await quarantined.getByRole('button', { name: 'Details' }).click()
+
+    const detail = page.locator('#detailDialog')
+    await expect(detail.getByText('Source mismatch / Quarantined', { exact: true })).toBeVisible()
+    await detail.getByText('Source metadata and verification notes').click()
+    await expect(detail.getByText(/Rejected NCT04027101.*baricitinib.*polymyalgia rheumatica/i)).toBeVisible()
+    await expect(detail.getByText(/No verified phase 2 efficacy result is reported/i)).toBeVisible()
+    await expect(detail.getByText(/verified brepocitinib dermatomyositis evidence is.*VALOR/i)).toBeVisible()
+
+    runtime.assertClean()
+  })
+
+  test('keeps regimen and source labels usable on a phone-sized listing', async ({ page }) => {
+    const runtime = watchRuntime(page)
+    await page.setViewportSize({ width: 390, height: 844 })
+    await page.goto(`${APP_ROUTE}#view=studies&q=RAPIDS-2`, { waitUntil: 'networkidle' })
+
+    const card = page.locator('.study-card').filter({
+      has: page.locator('[data-study="s116-rapids-2"]'),
+    }).first()
+    await expect(card).toBeVisible()
+    await expect(card).toContainText('62.5 mg twice daily for 4 weeks')
+    await expect(card).toContainText('125 mg twice daily for 20 weeks')
+    const dimensions = await page.evaluate(() => ({
+      viewport: window.innerWidth,
+      body: document.documentElement.scrollWidth,
+    }))
+    expect(dimensions.body).toBeLessThanOrEqual(dimensions.viewport)
+
+    runtime.assertClean()
+  })
+})


### PR DESCRIPTION
## Outcome

Makes every one of the 214 evidence listings identifiable from the card/table title and adds explicit study-regimen detail with provenance and missingness labels.

## Evidence and dispositions

- Engineering: PASS. Adds deterministic source transformation, a pinned 142-record ClinicalTrials.gov snapshot, exact artifact hashes, and denominator checks.
- Listing identity: PASS. 214/214 rows have unique identifiable display titles; generic labels such as Phase 2 randomized trial are expanded with intervention and condition.
- Regimen accounting: 72 record-backed dose, 31 registry-backed dose, 2 primary-publication-backed dose, 18 variable/multi-study regimens, 1 registry schedule without numeric dose, 89 explicit dose-not-reported, and 1 quarantined source mismatch. Total 214/214.
- Source identity: CORRECTED or QUARANTINED. DETERMINE is corrected to NCT03813160; BLISTER to ISRCTN13704604; the unrelated RAPIDS-2 lymphoma NCT is removed; the brepocitinib phase 2 row is quarantined because its cited NCT resolves to baricitinib in polymyalgia rheumatica.
- Clinical/faculty review: PENDING. The normalization and primary-source reconciliation are not a clinical-content release authorization.
- Deployment: NOT PERFORMED. This PR does not merge or deploy itself.

## Verification

- node --test site/scripts/rheum-derm-evidence-details.test.mjs: 5/5 pass
- focused Playwright Chromium suite: 4/4 pass, including 390 px mobile overflow check
- npm test: 217/217 pass
- npm run build: pass
- enhanced dashboard: 1,237,210 bytes, SHA-256 5648daf1a29433105d1a4ec7b83b1bcdf3fdab201b05dbf49ee36d37e076d5a7

## Residual risk

- 89 rows still lack a reportable numeric dose in the current normalized or linked registry data; the UI now states that limitation rather than inventing a regimen.
- One source-mismatched record remains quarantined pending a matching primary source.
- Repository rigor-toolkit gates are not wired in this repo, so the PR uses local exact-hash, denominator, unit, browser, and build gates instead.
- Vite reported existing deprecation and bundle-size warnings during build.